### PR TITLE
Refresh computed state before calling PostHandle func

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -31,6 +31,19 @@ func NewContext(parent context.Context, request *requestInfo) *Context {
 	}
 }
 
+// ForRefresh リフレッシュのためのContextを現在のContextを元に作成して返す
+//
+// 現在のContextが親Contextとなる
+func (c *Context) ForRefresh() *Context {
+	return NewContext(c, &requestInfo{
+		requestType:       c.request.requestType,
+		source:            c.request.source,
+		action:            c.request.action,
+		resourceGroupName: c.request.resourceGroupName,
+		refresh:           true,
+	})
+}
+
 func (c *Context) Request() *requestInfo {
 	return c.request
 }

--- a/core/core.go
+++ b/core/core.go
@@ -121,30 +121,11 @@ func (c *Core) generateJobID(ctx *Context) string {
 
 func (c *Core) handle(ctx *Context) error {
 	//対象リソースグループを取得
-	resourceGroup, err := c.targetResourceGroup(ctx)
+	rg, err := c.targetResourceGroup(ctx)
 	if err != nil {
 		return err
 	}
-
-	allDesired, err := resourceGroup.ComputeAll(ctx, c.config.APIClient())
-	if err != nil {
-		return err
-	}
-
-	handlers, err := resourceGroup.Handlers(c.config.Handlers())
-	if err != nil {
-		return err
-	}
-
-	for _, desired := range allDesired {
-		for _, handler := range handlers {
-			if err := handler.Handle(ctx, desired); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
+	return rg.HandleAll(ctx, c.config.APIClient(), c.config.Handlers())
 }
 
 func (c *Core) targetResourceGroup(ctx *Context) (*ResourceGroup, error) {

--- a/core/handler.go
+++ b/core/handler.go
@@ -63,14 +63,20 @@ func (h *Handler) Handle(ctx *Context, computed Computed) error {
 	if h.isBuiltin() {
 		return h.handleBuiltin(ctx, computed)
 	}
-	return h.handle(ctx, computed)
+	return h.handleExternal(ctx, computed)
 }
 
-func (h *Handler) handleBuiltin(ctx *Context, computed Computed) error {
+type handleArg struct {
+	preHandle  func(request *handler.PreHandleRequest) error
+	handle     func(request *handler.HandleRequest) error
+	postHandle func(request *handler.PostHandleRequest) error
+}
+
+func (h *Handler) handle(ctx *Context, computed Computed, handleArg *handleArg) error {
 	req := ctx.Request()
 
-	if actualHandler, ok := h.BuiltinHandler.(handlers.PreHandler); ok {
-		err := actualHandler.PreHandle(&handler.PreHandleRequest{
+	if handleArg.preHandle != nil {
+		if err := handleArg.preHandle(&handler.PreHandleRequest{
 			Source:            req.source,
 			Action:            req.action,
 			ResourceGroupName: req.resourceGroupName,
@@ -78,14 +84,13 @@ func (h *Handler) handleBuiltin(ctx *Context, computed Computed) error {
 			Instruction:       computed.Instruction(),
 			Current:           computed.Current(),
 			Desired:           computed.Desired(),
-		}, &builtinResponseSender{})
-		if err != nil {
+		}); err != nil {
 			return err
 		}
 	}
 
-	if actualHandler, ok := h.BuiltinHandler.(handlers.Handler); ok {
-		err := actualHandler.Handle(&handler.HandleRequest{
+	if handleArg.handle != nil {
+		if err := handleArg.handle(&handler.HandleRequest{
 			Source:            req.source,
 			Action:            req.action,
 			ResourceGroupName: req.resourceGroupName,
@@ -93,14 +98,14 @@ func (h *Handler) handleBuiltin(ctx *Context, computed Computed) error {
 			Instruction:       computed.Instruction(),
 			Current:           computed.Current(),
 			Desired:           computed.Desired(),
-		}, &builtinResponseSender{})
-		if err != nil {
+		}); err != nil {
 			return err
 		}
 	}
 
-	if actualHandler, ok := h.BuiltinHandler.(handlers.PostHandler); ok {
-		err := actualHandler.PostHandle(&handler.PostHandleRequest{
+	if handleArg.postHandle != nil {
+		// TODO Refreshの実行
+		if err := handleArg.postHandle(&handler.PostHandleRequest{
 			Source:            req.source,
 			Action:            req.action,
 			ResourceGroupName: req.resourceGroupName,
@@ -108,8 +113,7 @@ func (h *Handler) handleBuiltin(ctx *Context, computed Computed) error {
 			Instruction:       computed.Instruction(),
 			Current:           computed.Current(),
 			Desired:           computed.Desired(),
-		}, &builtinResponseSender{})
-		if err != nil {
+		}); err != nil {
 			return err
 		}
 	}
@@ -117,7 +121,31 @@ func (h *Handler) handleBuiltin(ctx *Context, computed Computed) error {
 	return nil
 }
 
-func (h *Handler) handle(ctx *Context, computed Computed) error {
+func (h *Handler) handleBuiltin(ctx *Context, computed Computed) error {
+	handleArg := &handleArg{}
+
+	if actualHandler, ok := h.BuiltinHandler.(handlers.PreHandler); ok {
+		handleArg.preHandle = func(req *handler.PreHandleRequest) error {
+			return actualHandler.PreHandle(req, &builtinResponseSender{})
+		}
+	}
+
+	if actualHandler, ok := h.BuiltinHandler.(handlers.Handler); ok {
+		handleArg.handle = func(req *handler.HandleRequest) error {
+			return actualHandler.Handle(req, &builtinResponseSender{})
+		}
+	}
+
+	if actualHandler, ok := h.BuiltinHandler.(handlers.PostHandler); ok {
+		handleArg.postHandle = func(req *handler.PostHandleRequest) error {
+			return actualHandler.PostHandle(req, &builtinResponseSender{})
+		}
+	}
+
+	return h.handle(ctx, computed, handleArg)
+}
+
+func (h *Handler) handleExternal(ctx *Context, computed Computed) error {
 	// TODO 簡易的な実装、後ほど整理&切り出し
 	conn, err := grpc.DialContext(ctx, h.Endpoint, grpc.WithInsecure())
 	if err != nil {
@@ -126,57 +154,30 @@ func (h *Handler) handle(ctx *Context, computed Computed) error {
 	defer conn.Close()
 
 	client := handler.NewHandleServiceClient(conn)
-	req := ctx.Request()
-
-	preHandleResponse, err := client.PreHandle(ctx, &handler.PreHandleRequest{
-		Source:            req.source,
-		Action:            req.action,
-		ResourceGroupName: req.resourceGroupName,
-		ScalingJobId:      req.ID(),
-		Instruction:       computed.Instruction(),
-		Current:           computed.Current(),
-		Desired:           computed.Desired(),
-	})
-	if err != nil {
-		return err
+	handleArg := &handleArg{
+		preHandle: func(req *handler.PreHandleRequest) error {
+			res, err := client.PreHandle(ctx, req)
+			if err != nil {
+				return err
+			}
+			return h.handleHandlerResponse(res)
+		},
+		handle: func(req *handler.HandleRequest) error {
+			res, err := client.Handle(ctx, req)
+			if err != nil {
+				return err
+			}
+			return h.handleHandlerResponse(res)
+		},
+		postHandle: func(req *handler.PostHandleRequest) error {
+			res, err := client.PostHandle(ctx, req)
+			if err != nil {
+				return err
+			}
+			return h.handleHandlerResponse(res)
+		},
 	}
-	if err := h.handleHandlerResponse(preHandleResponse); err != nil {
-		return err
-	}
-
-	handleResponse, err := client.Handle(ctx, &handler.HandleRequest{
-		Source:            req.source,
-		Action:            req.action,
-		ResourceGroupName: req.resourceGroupName,
-		ScalingJobId:      req.ID(),
-		Instruction:       computed.Instruction(),
-		Current:           computed.Current(),
-		Desired:           computed.Desired(),
-	})
-	if err != nil {
-		return err
-	}
-	if err := h.handleHandlerResponse(handleResponse); err != nil {
-		return err
-	}
-
-	postHandleResponse, err := client.PostHandle(ctx, &handler.PostHandleRequest{
-		Source:            req.source,
-		Action:            req.action,
-		ResourceGroupName: req.resourceGroupName,
-		ScalingJobId:      req.ID(),
-		Instruction:       computed.Instruction(),
-		Current:           computed.Current(),
-		Desired:           computed.Desired(),
-	})
-	if err != nil {
-		return err
-	}
-	if err := h.handleHandlerResponse(postHandleResponse); err != nil {
-		return err
-	}
-
-	return nil
+	return h.handle(ctx, computed, handleArg)
 }
 
 type handlerResponseReceiver interface {

--- a/core/request.go
+++ b/core/request.go
@@ -20,8 +20,8 @@ type RequestTypes int
 
 const (
 	requestTypeUnknown RequestTypes = iota // nolint
-	requestTypeUp
-	requestTypeDown
+	requestTypeUp                          // スケールアップ or スケールアウト
+	requestTypeDown                        // スケールダウン or スケールイン
 )
 
 func (r RequestTypes) String() string {
@@ -40,6 +40,7 @@ type requestInfo struct {
 	source            string
 	action            string
 	resourceGroupName string
+	refresh           bool
 }
 
 func (r *requestInfo) String() string {

--- a/core/resource_group_test.go
+++ b/core/resource_group_test.go
@@ -1,0 +1,167 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sacloud/autoscaler/handler"
+	"github.com/sacloud/autoscaler/handlers"
+	"github.com/sacloud/autoscaler/handlers/builtins"
+	"github.com/sacloud/autoscaler/handlers/stub"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceGroup_handlers(t *testing.T) {
+	allHandlers := Handlers{
+		{
+			Type: "dummy",
+			Name: "dummy1",
+		},
+		{
+			Type: "dummy",
+			Name: "dummy2",
+		},
+	}
+
+	type fields struct {
+		HandlerConfigs []*ResourceHandlerConfig
+		Resources      Resources
+		Name           string
+	}
+	type args struct {
+		allHandlers Handlers
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    Handlers
+		wantErr bool
+	}{
+		{
+			name: "returns if HandlerConfigs is empty",
+			fields: fields{
+				HandlerConfigs: nil,
+				Name:           "empty",
+			},
+			args: args{
+				allHandlers: allHandlers,
+			},
+			want:    allHandlers,
+			wantErr: false,
+		},
+		{
+			name: "returns error if invalid HandlerConfigs is specified",
+			fields: fields{
+				HandlerConfigs: []*ResourceHandlerConfig{
+					{
+						Name: "not-exists",
+					},
+				},
+				Name: "not-exists",
+			},
+			args: args{
+				allHandlers: allHandlers,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "returns with filtering by HandlerConfigs",
+			fields: fields{
+				HandlerConfigs: []*ResourceHandlerConfig{
+					{
+						Name: "dummy1",
+					},
+				},
+				Name: "filter",
+			},
+			args: args{
+				allHandlers: allHandlers,
+			},
+			want: Handlers{
+				{
+					Type: "dummy",
+					Name: "dummy1",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rg := &ResourceGroup{
+				HandlerConfigs: tt.fields.HandlerConfigs,
+				Resources:      tt.fields.Resources,
+				Name:           tt.fields.Name,
+			}
+			got, err := rg.handlers(tt.args.allHandlers)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handlers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("handlers() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResourceGroup_HandleAll(t *testing.T) {
+	called := 0
+	rg := &ResourceGroup{
+		HandlerConfigs: nil,
+		Resources: Resources{
+			&stubResource{
+				ResourceBase: &ResourceBase{},
+				computeFunc: func(ctx *Context, apiClient sacloud.APICaller) ([]Computed, error) {
+					called++
+					return []Computed{&stubComputed{
+						instruction: handler.ResourceInstructions_NOOP,
+						current:     &handler.Resource{},
+						desired:     &handler.Resource{},
+					}}, nil
+				},
+			},
+		},
+		Name: "test",
+	}
+
+	rg.handleAll(testContext(), testAPIClient, Handlers{ // nolint
+		{
+			Type: "stub",
+			Name: "stub",
+			BuiltinHandler: &builtins.Handler{
+				Builtin: &stub.Handler{
+					PreHandleFunc: func(request *handler.PreHandleRequest, sender handlers.ResponseSender) error {
+						return nil
+					},
+					HandleFunc: func(request *handler.HandleRequest, sender handlers.ResponseSender) error {
+						return nil
+					},
+					PostHandleFunc: func(request *handler.PostHandleRequest, sender handlers.ResponseSender) error {
+						return nil
+					},
+				},
+			},
+		},
+	})
+
+	// handleAll中にCompute()が2回(初回+リフレッシュ)呼ばれているか?
+	require.Equal(t, 2, called)
+}

--- a/core/resource_server.go
+++ b/core/resource_server.go
@@ -58,10 +58,6 @@ func (s *Server) Validate() error {
 }
 
 func (s *Server) Compute(ctx *Context, apiClient sacloud.APICaller) ([]Computed, error) {
-	if len(s.ComputedCache) != 0 {
-		return s.ComputedCache, nil
-	}
-
 	if err := s.Validate(); err != nil {
 		return nil, err
 	}
@@ -140,11 +136,8 @@ func (cs *computedServer) desiredPlan(ctx *Context, current *sacloud.Server, pla
 	// TODO s.Plansの並べ替えを考慮する
 
 	if ctx.Request().refresh {
-		// リフレッシュ時は現在のプランをそのまま返す
-		return &ServerPlan{
-			Core:   current.CPU,
-			Memory: current.GetMemoryGB(),
-		}
+		// リフレッシュ時はプラン変更しない
+		return nil
 	}
 
 	switch ctx.Request().requestType {

--- a/core/resource_server.go
+++ b/core/resource_server.go
@@ -139,6 +139,14 @@ func (cs *computedServer) desiredPlan(ctx *Context, current *sacloud.Server, pla
 
 	// TODO s.Plansの並べ替えを考慮する
 
+	if ctx.Request().refresh {
+		// リフレッシュ時は現在のプランをそのまま返す
+		return &ServerPlan{
+			Core:   current.CPU,
+			Memory: current.GetMemoryGB(),
+		}
+	}
+
 	switch ctx.Request().requestType {
 	case requestTypeUp:
 		fn = func(i int) *ServerPlan {

--- a/core/resource_stub_test.go
+++ b/core/resource_stub_test.go
@@ -1,0 +1,54 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"github.com/sacloud/autoscaler/handler"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
+
+type stubResource struct {
+	*ResourceBase `yaml:",inline"`
+	computeFunc   func(ctx *Context, apiClient sacloud.APICaller) ([]Computed, error)
+}
+
+func (r *stubResource) Validate() error {
+	return nil
+}
+
+func (r *stubResource) Compute(ctx *Context, apiClient sacloud.APICaller) ([]Computed, error) {
+	if r.computeFunc != nil {
+		return r.computeFunc(ctx, apiClient)
+	}
+	return nil, nil
+}
+
+type stubComputed struct {
+	instruction handler.ResourceInstructions
+	current     *handler.Resource
+	desired     *handler.Resource
+}
+
+func (c *stubComputed) Instruction() handler.ResourceInstructions {
+	return c.instruction
+}
+
+func (c *stubComputed) Current() *handler.Resource {
+	return c.current
+}
+
+func (c *stubComputed) Desired() *handler.Resource {
+	return c.desired
+}

--- a/handlers/stub/handler.go
+++ b/handlers/stub/handler.go
@@ -1,0 +1,57 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stub
+
+import (
+	"github.com/sacloud/autoscaler/handler"
+	"github.com/sacloud/autoscaler/handlers"
+	"github.com/sacloud/autoscaler/version"
+)
+
+// Handler 単体テスト用のスタブハンドラ
+type Handler struct {
+	PreHandleFunc  func(*handler.PreHandleRequest, handlers.ResponseSender) error
+	HandleFunc     func(*handler.HandleRequest, handlers.ResponseSender) error
+	PostHandleFunc func(*handler.PostHandleRequest, handlers.ResponseSender) error
+}
+
+func (h *Handler) Name() string {
+	return "stub"
+}
+
+func (h *Handler) Version() string {
+	return version.FullVersion()
+}
+
+func (h *Handler) PreHandle(req *handler.PreHandleRequest, sender handlers.ResponseSender) error {
+	if h.PreHandleFunc != nil {
+		return h.PreHandleFunc(req, sender)
+	}
+	return nil
+}
+
+func (h *Handler) Handle(req *handler.HandleRequest, sender handlers.ResponseSender) error {
+	if h.HandleFunc != nil {
+		return h.HandleFunc(req, sender)
+	}
+	return nil
+}
+
+func (h *Handler) PostHandle(req *handler.PostHandleRequest, sender handlers.ResponseSender) error {
+	if h.PostHandleFunc != nil {
+		return h.PostHandleFunc(req, sender)
+	}
+	return nil
+}


### PR DESCRIPTION
#19 の後続PR

- PostHandle呼び出し前のリフレッシュ
- ~RequestTypeをUp/Downに加えRefreshを追加~
- requestInfo(Contextに保持)にRefreshであることを示すフィールドを追加

これにより、`PreHandle`と`Handle`には同じパラメータが、`PostHandle`にはリフレッシュ後のパラメータが渡されるようになる。
リフレッシュ後に返される`Computed`のCurrent/Desiredは同じ値を返す。

UPDATE: RequestTypeはHandlersに渡すパラエータであるため、`Refresh`を追加するのは適切ではない。  
このためContextに保持しているrequestInfoにリフレッシュであることを示すフィールドを追加して対応する。