### PR TITLE
Prototype: Grafana Inputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,9 @@ gen-request:
 gen-handler:
 	(cd docs; protoc --go_out=../handler --go_opt=paths=source_relative --go-grpc_out=../handler --go-grpc_opt=paths=source_relative handler.proto)
 
-.PHONY: build build-all build-autoscaler build-inputs-direct
+.PHONY: build build-autoscaler build-inputs-direct build-inputs-grafana build-handlers-fake
 
-build: build-autoscaler build-inputs-direct build-handlers-fake
+build: build-autoscaler build-inputs-direct build-inputs-grafana build-handlers-fake
 
 build-autoscaler: bin/autoscaler
 bin/autoscaler: $(GO_FILES)
@@ -60,6 +60,10 @@ bin/autoscaler: $(GO_FILES)
 build-inputs-direct: bin/autoscaler-inputs-direct
 bin/autoscaler-inputs-direct: $(GO_FILES)
 	GOOS=$${OS:-"`go env GOOS`"} GOARCH=$${ARCH:-"`go env GOARCH`"} CGO_ENABLED=0 go build -ldflags=$(BUILD_LDFLAGS) -o bin/autoscaler-inputs-direct cmd/autoscaler-inputs-direct/main.go
+
+build-inputs-grafana: bin/autoscaler-inputs-grafana
+bin/autoscaler-inputs-grafana: $(GO_FILES)
+	GOOS=$${OS:-"`go env GOOS`"} GOARCH=$${ARCH:-"`go env GOARCH`"} CGO_ENABLED=0 go build -ldflags=$(BUILD_LDFLAGS) -o bin/autoscaler-inputs-grafana cmd/autoscaler-inputs-grafana/main.go
 
 build-handlers-fake: bin/autoscaler-handlers-fake
 bin/autoscaler-handlers-fake: $(GO_FILES)

--- a/cmd/autoscaler-inputs-grafana/main.go
+++ b/cmd/autoscaler-inputs-grafana/main.go
@@ -1,0 +1,229 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// AutoScaler Inputs: Direct
+//
+// Usage:
+//   autoscaler-inputs-direct [flags] up|down|status
+//
+// Arguments:
+//   up: run the Up func
+//   down: run the Down func
+//
+// Flags:
+//   -dest: (optional) URL of gRPC endpoint of AutoScaler Core. default:`unix:autoscaler.sock`
+//   -action: (optional) Name of the action to perform. default:`default`
+//   -group: (optional) Name of the target resource group. default:`default`
+//   -source: (optional) A string representing the request source, passed to AutoScaler Core. default:`default`
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/sacloud/autoscaler/defaults"
+	"github.com/sacloud/autoscaler/request"
+	"github.com/sacloud/autoscaler/version"
+	"google.golang.org/grpc"
+)
+
+func showUsage() {
+	fmt.Println("usage: autoscaler-inputs-grafana [flags]")
+	flag.Usage()
+}
+
+func main() {
+	var dest, addr string
+	flag.StringVar(&dest, "dest", defaults.CoreSocketAddr, "URL of gRPC endpoint of AutoScaler Core")
+	flag.StringVar(&addr, "addr", ":3001", "the TCP address for the server to listen on")
+
+	var showHelp, showVersion bool
+	flag.BoolVar(&showHelp, "help", false, "Show help")
+	flag.BoolVar(&showVersion, "version", false, "Show version")
+
+	flag.Parse()
+
+	// TODO add flag validation
+
+	// Note: 引数は無視
+
+	switch {
+	case showHelp:
+		showUsage()
+		return
+	case showVersion:
+		fmt.Println(version.FullVersion())
+		return
+	default:
+		if err := listenAndServe(addr, dest); err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
+func listenAndServe(addr, coreAddr string) error {
+	handler := http.DefaultServeMux
+
+	handler.HandleFunc("/up", func(w http.ResponseWriter, req *http.Request) {
+		handleFunc(coreAddr, "up", w, req)
+	})
+	handler.HandleFunc("/down", func(w http.ResponseWriter, req *http.Request) {
+		handleFunc(coreAddr, "down", w, req)
+	})
+	handler.HandleFunc("/healthz", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) // nolint
+	})
+
+	log.Printf("autoscaler-inputs-grafana: started on %s\n", addr)
+	return http.ListenAndServe(addr, handler)
+}
+
+func handleFunc(coreAddr, requestType string, w http.ResponseWriter, req *http.Request) {
+	scalingReq, err := parseRequest(requestType, req)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if scalingReq == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	requester := &requester{dest: coreAddr}
+	if err := requester.send(scalingReq); err != nil {
+		log.Println("[ERROR]: ", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok")) // nolint
+}
+
+type scalingRequest struct {
+	source      string
+	action      string
+	groupName   string
+	requestType string
+}
+
+const (
+	// StateOk       State = "ok"
+	// StatePaused   State = "paused"
+
+	StateAlerting State = "alerting"
+
+	// StatePending  State = "pending"
+	// StateNoData   State = "no_data"
+)
+
+type State string
+
+type grafanaWebhookBody struct {
+	//Title       string                   `json:"title"`
+	//RuleID      int                      `json:"ruleId"`
+	//RuleName    string                   `json:"ruleName"`
+	//RuleURL     string                   `json:"ruleUrl"`
+	State State `json:"state"`
+	//Message     string                   `json:"message"`
+}
+
+func parseRequest(requestType string, req *http.Request) (*scalingRequest, error) {
+	dump, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		return nil, err
+	}
+	log.Println("webhook received:", string(dump))
+
+	if req.Method == http.MethodPost || req.Method == http.MethodPut {
+		reqData, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var received grafanaWebhookBody
+		if err := json.Unmarshal(reqData, &received); err != nil {
+			return nil, err
+		}
+		if received.State != StateAlerting { // alerting以外は処理しない
+			return nil, nil
+		}
+
+		queryStrings := req.URL.Query()
+		source := queryStrings.Get("source")
+		if source == "" {
+			source = defaults.SourceName
+		}
+		action := queryStrings.Get("action")
+		if action == "" {
+			action = defaults.ActionName
+		}
+		groupName := queryStrings.Get("resource_group_name")
+		if groupName == "" {
+			groupName = defaults.ResourceGroupName
+		}
+		return &scalingRequest{
+			source:      source,
+			action:      action,
+			groupName:   groupName,
+			requestType: requestType,
+		}, nil
+	}
+	return nil, nil
+}
+
+type requester struct {
+	dest string
+}
+
+func (r *requester) send(scalingReq *scalingRequest) error {
+	if scalingReq == nil {
+		return nil
+	}
+	ctx := context.Background()
+	// TODO 簡易的な実装、後ほど整理&切り出し
+	conn, err := grpc.DialContext(ctx, r.dest, grpc.WithInsecure())
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	req := request.NewScalingServiceClient(conn)
+	var f func(ctx context.Context, in *request.ScalingRequest, opts ...grpc.CallOption) (*request.ScalingResponse, error)
+
+	switch scalingReq.requestType {
+	case "up":
+		f = req.Up
+	case "down":
+		f = req.Down
+	default:
+		return fmt.Errorf("invalid request type: %s", scalingReq.requestType)
+	}
+	res, err := f(ctx, &request.ScalingRequest{
+		Source:            scalingReq.source,
+		Action:            scalingReq.action,
+		ResourceGroupName: scalingReq.groupName,
+	})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("status: %s, job-id: %s\n", res.Status, res.ScalingJobId)
+	return nil
+}

--- a/cmd/autoscaler-inputs-grafana/test/webhook.json
+++ b/cmd/autoscaler-inputs-grafana/test/webhook.json
@@ -1,0 +1,22 @@
+{
+  "dashboardId":1,
+  "evalMatches":[
+    {
+      "value":1,
+      "metric":"Count",
+      "tags":{}
+    }
+  ],
+  "imageUrl":"https://grafana.com/assets/img/blog/mixed_styles.png",
+  "message":"Notification Message",
+  "orgId":1,
+  "panelId":2,
+  "ruleId":1,
+  "ruleName":"Panel Title alert",
+  "ruleUrl":"http://localhost:3000/d/hZ7BuVbWz/test-dashboard?fullscreen\u0026edit\u0026tab=alert\u0026panelId=2\u0026orgId=1",
+  "state":"alerting",
+  "tags":{
+    "tag name":"tag value"
+  },
+  "title":"[Alerting] Panel Title alert"
+}


### PR DESCRIPTION
GrafanaからのWebhookを受けてCoreへリクエストを投げるためのInputsのプロトタイプ実装
とりあえず動くところまで実装

### 動かし方

```sh
# autoscaler本体の起動
$ bin/autoscaler

# Grafana Inputsの起動(デフォルトでは:3001でリッスン)
$ bin/autoscaler-inputs-grafana

# curlでWebhookの代替
# スケールアップ
$ curl -X POST -d @cmd/autoscaler-inputs-grafana/test/webhook.json localhost:3001/up 
# スケールダウン
$ curl -X POST -d @cmd/autoscaler-inputs-grafana/test/webhook.json localhost:3001/down
```
