### PR TITLE
Use ComputedCache in resource graph walking

### DIFF
--- a/core/resource_group.go
+++ b/core/resource_group.go
@@ -191,18 +191,13 @@ func (rg *ResourceGroup) handleAll(ctx *Context, apiClient sacloud.APICaller, ha
 
 func (rg *ResourceGroup) resourceWalkFuncs(ctx *Context, apiClient sacloud.APICaller, handlers Handlers) (ResourceWalkFunc, ResourceWalkFunc) {
 	// TODO 並列化
-	// NOTE: 並列化したときにforwardFnとbackwardFnでcomputedへの代入がコンフリクトする可能性がある
-	var computed []Computed
 	forwardFn := func(resource Resource) error {
-		c, err := resource.Compute(ctx, apiClient)
-		if err != nil {
-			return err
-		}
-		computed = c
-		return nil
+		_, err := resource.Compute(ctx, apiClient)
+		return err
 	}
 
 	backwardFn := func(resource Resource) error {
+		computed := resource.Computed()
 		// preHandle
 		if err := rg.handleAllByFunc(computed, handlers, func(h *Handler, c Computed) error {
 			return h.PreHandle(ctx, c)

--- a/core/resource_stub_test.go
+++ b/core/resource_stub_test.go
@@ -30,7 +30,9 @@ func (r *stubResource) Validate() error {
 
 func (r *stubResource) Compute(ctx *Context, apiClient sacloud.APICaller) ([]Computed, error) {
 	if r.computeFunc != nil {
-		return r.computeFunc(ctx, apiClient)
+		computed, err := r.computeFunc(ctx, apiClient)
+		r.ComputedCache = computed
+		return computed, err
 	}
 	return nil, nil
 }


### PR DESCRIPTION
#29 のフォロー

forwardFn/backwardFnの間でローカル変数でComputedを受け渡していたが、これをComputedCacheを利用するように修正。  
これにより並列化した場合でも正しい宛先への参照を保持できる。