### PR TITLE
Added Disabled field to builtin handlers

### DIFF
--- a/core/handler.go
+++ b/core/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sacloud/autoscaler/handlers"
 	"github.com/sacloud/autoscaler/handlers/builtins"
 	"github.com/sacloud/autoscaler/handlers/elb"
+	"github.com/sacloud/autoscaler/handlers/logging"
 	"github.com/sacloud/autoscaler/handlers/router"
 	"github.com/sacloud/autoscaler/handlers/server"
 	"google.golang.org/grpc"
@@ -30,14 +31,14 @@ import (
 type Handlers []*Handler
 
 var BuiltinHandlers = Handlers{
-	// TODO ログの扱いを決めるまでコメントアウトしたまま残しておく
-	//{
-	//	Type: "logging",
-	//	Name: "logging",
-	//	BuiltinHandler: &builtins.Handler{
-	//		Builtin: &logging.Handler{},
-	//	},
-	//},
+	{
+		Type: "logging",
+		Name: "logging",
+		BuiltinHandler: &builtins.Handler{
+			Builtin: &logging.Handler{},
+		},
+		Disabled: true,
+	},
 	{
 		Type: "server-vertical-scaler",
 		Name: "server-vertical-scaler",
@@ -68,6 +69,7 @@ type Handler struct {
 	Name           string          `yaml:"name"`     // ハンドラーを識別するための名称 同一Typeで複数のハンドラーが存在する場合が存在するため、Nameで一意に識別する
 	Endpoint       string          `yaml:"endpoint"` // カスタムハンドラーの場合にのみ指定
 	BuiltinHandler handlers.Server `yaml:"-"`        // ビルトインハンドラーの場合のみ指定
+	Disabled       bool            `yaml:"-"`        // ビルトインハンドラーの場合のみ指定
 }
 
 func (h *Handler) isBuiltin() bool {

--- a/core/resource_group.go
+++ b/core/resource_group.go
@@ -260,10 +260,17 @@ func (rg *ResourceGroup) clearCacheAll() {
 //
 // TODO Configurationにactionsの定義を実装したらそちらも加味したハンドラーを返すようにする
 func (rg *ResourceGroup) handlers(allHandlers Handlers) (Handlers, error) {
-	if len(rg.HandlerConfigs) == 0 {
-		return allHandlers, nil
-	}
 	var handlers Handlers
+
+	if len(rg.HandlerConfigs) == 0 {
+		for _, h := range allHandlers {
+			if !h.Disabled {
+				handlers = append(handlers, h)
+			}
+		}
+		return handlers, nil
+	}
+
 	for _, conf := range rg.HandlerConfigs {
 		var found *Handler
 		for _, h := range allHandlers {

--- a/core/resource_group_test.go
+++ b/core/resource_group_test.go
@@ -37,6 +37,11 @@ func TestResourceGroup_handlers(t *testing.T) {
 			Type: "dummy",
 			Name: "dummy2",
 		},
+		{
+			Type:     "dummy",
+			Name:     "dummy3",
+			Disabled: true,
+		},
 	}
 
 	type fields struct {
@@ -55,7 +60,7 @@ func TestResourceGroup_handlers(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "returns if HandlerConfigs is empty",
+			name: "returns all enabled handlers if HandlerConfigs is empty",
 			fields: fields{
 				HandlerConfigs: nil,
 				Name:           "empty",
@@ -63,7 +68,16 @@ func TestResourceGroup_handlers(t *testing.T) {
 			args: args{
 				allHandlers: allHandlers,
 			},
-			want:    allHandlers,
+			want: Handlers{
+				{
+					Type: "dummy",
+					Name: "dummy1",
+				},
+				{
+					Type: "dummy",
+					Name: "dummy2",
+				},
+			},
 			wantErr: false,
 		},
 		{
@@ -83,11 +97,11 @@ func TestResourceGroup_handlers(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "returns with filtering by HandlerConfigs",
+			name: "returns handler with filtering by HandlerConfigs even at Disabled:true",
 			fields: fields{
 				HandlerConfigs: []*ResourceHandlerConfig{
 					{
-						Name: "dummy1",
+						Name: "dummy3",
 					},
 				},
 				Name: "filter",
@@ -97,8 +111,9 @@ func TestResourceGroup_handlers(t *testing.T) {
 			},
 			want: Handlers{
 				{
-					Type: "dummy",
-					Name: "dummy1",
+					Type:     "dummy",
+					Name:     "dummy3",
+					Disabled: true,
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
closes #31 

ビルトインハンドラに`Disabled`フィールドを追加する
Disabledなハンドラはリソースグループのハンドラー設定で明示しない限り利用されない。