### PR TITLE
Added GSLB servers handler

### DIFF
--- a/core/handler.go
+++ b/core/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sacloud/autoscaler/handlers"
 	"github.com/sacloud/autoscaler/handlers/builtins"
 	"github.com/sacloud/autoscaler/handlers/elb"
+	"github.com/sacloud/autoscaler/handlers/gslb"
 	"github.com/sacloud/autoscaler/handlers/logging"
 	"github.com/sacloud/autoscaler/handlers/router"
 	"github.com/sacloud/autoscaler/handlers/server"
@@ -40,13 +41,6 @@ var BuiltinHandlers = Handlers{
 		Disabled: true,
 	},
 	{
-		Type: "server-vertical-scaler",
-		Name: "server-vertical-scaler",
-		BuiltinHandler: &builtins.Handler{
-			Builtin: &server.VerticalScaleHandler{},
-		},
-	},
-	{
 		Type: "elb-vertical-scaler",
 		Name: "elb-vertical-scaler",
 		BuiltinHandler: &builtins.Handler{
@@ -61,10 +55,24 @@ var BuiltinHandlers = Handlers{
 		},
 	},
 	{
+		Type: "gslb-servers-handler",
+		Name: "gslb-servers-handler",
+		BuiltinHandler: &builtins.Handler{
+			Builtin: &gslb.ServersHandler{},
+		},
+	},
+	{
 		Type: "router-vertical-scaler",
 		Name: "router-vertical-scaler",
 		BuiltinHandler: &builtins.Handler{
 			Builtin: &router.VerticalScaleHandler{},
+		},
+	},
+	{
+		Type: "server-vertical-scaler",
+		Name: "server-vertical-scaler",
+		BuiltinHandler: &builtins.Handler{
+			Builtin: &server.VerticalScaleHandler{},
 		},
 	},
 	// TODO その他ビルトインを追加

--- a/example-autoscaler.yaml
+++ b/example-autoscaler.yaml
@@ -29,6 +29,36 @@ resources:
       #     - cps: 500
       #     - cps: 1000
 
+      # エンハンスドロードバランサ + サーバ(垂直スケール)
+      # サーバの垂直スケール時にELBからのデタッチ/アタッチを行う
+      # - type: ELB
+      #   selector:
+      #     names: ["example"]
+      #   resources:
+      #     - type: Server
+      #       selector:
+      #         names: ["example1"]
+      #         zone: "is1a"
+      #     - type: Server
+      #       selector:
+      #         names: ["example2"]
+      #         zone: "is1a"
+
+      # GSLB + サーバ(垂直スケール)
+      # サーバの垂直スケール時にGSLBからのデタッチ/アタッチを行う
+      # - type: GSLB
+      #   selector:
+      #     names: ["example"]
+      #   resources:
+      #     - type: Server
+      #       selector:
+      #         names: ["example1"]
+      #         zone: "is1a"
+      #     - type: Server
+      #       selector:
+      #         names: ["example2"]
+      #         zone: "is1a"
+
       # ルータ(垂直スケール)
       # - type: Router
       #   selector:

--- a/handlers/gslb/servers_handler.go
+++ b/handlers/gslb/servers_handler.go
@@ -1,0 +1,165 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gslb
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/autoscaler/handler"
+	"github.com/sacloud/autoscaler/handlers"
+	"github.com/sacloud/autoscaler/version"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// ServersHandler GSLB配下のサーバのアタッチ/デタッチを行うためのハンドラ
+//
+// リクエストされたリソースの直近の親リソースがGSLBの場合に処理を行う
+//   - PreHandle: GSLBからのデタッチ
+//   - Handle: なにもしない
+//   - PostHandle: GSLBへのアタッチ
+//
+// アタッチ/デタッチは各サーバのEnabledを制御することで行う
+// もしGSLBにサーバが1台しか登録されていない場合はサービス停止が発生するため注意が必要
+type ServersHandler struct {
+	handlers.SakuraCloudFlagCustomizer
+}
+
+func (h *ServersHandler) Name() string {
+	return "gslb-servers-handler"
+}
+
+func (h *ServersHandler) Version() string {
+	return version.FullVersion()
+}
+
+func (h *ServersHandler) PreHandle(req *handler.PreHandleRequest, sender handlers.ResponseSender) error {
+	ctx := context.Background()
+
+	if err := sender.Send(&handler.HandleResponse{
+		ScalingJobId: req.ScalingJobId,
+		Status:       handler.HandleResponse_ACCEPTED,
+		Log:          fmt.Sprintf("%s: accepted: %s", h.Name(), req.String()),
+	}); err != nil {
+		return err
+	}
+
+	if req.Instruction == handler.ResourceInstructions_UPDATE && h.shouldHandle(req.Desired) {
+		// TODO 入力値のバリデーション
+		server := req.Desired.GetServer()
+		gslb := server.Parent.GetGslb() // バリデーション済みなためnilチェック不要
+		if err := h.handle(ctx, req.ScalingJobId, server, gslb, sender, false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *ServersHandler) PostHandle(req *handler.PostHandleRequest, sender handlers.ResponseSender) error {
+	ctx := context.Background()
+
+	if err := sender.Send(&handler.HandleResponse{
+		ScalingJobId: req.ScalingJobId,
+		Status:       handler.HandleResponse_ACCEPTED,
+		Log:          fmt.Sprintf("%s: accepted: %s", h.Name(), req.String()),
+	}); err != nil {
+		return err
+	}
+
+	if req.Result == handler.PostHandleRequest_UPDATED && h.shouldHandle(req.Desired) {
+		// TODO 入力値のバリデーション
+		server := req.Desired.GetServer()
+		gslb := server.Parent.GetGslb() // バリデーション済みなためnilチェック不要
+		if err := h.handle(ctx, req.ScalingJobId, server, gslb, sender, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *ServersHandler) shouldHandle(desired *handler.Resource) bool {
+	server := desired.GetServer()
+	if server != nil {
+		parent := server.Parent
+		if parent != nil {
+			return parent.GetGslb() != nil
+		}
+	}
+	return false
+}
+
+func (h *ServersHandler) handle(ctx context.Context, jobID string, server *handler.Server, gslb *handler.GSLB, sender handlers.ResponseSender, attach bool) error {
+	if err := sender.Send(&handler.HandleResponse{
+		ScalingJobId: jobID,
+		Status:       handler.HandleResponse_RUNNING,
+	}); err != nil {
+		return err
+	}
+
+	gslbOp := sacloud.NewGSLBOp(h.APIClient())
+	current, err := gslbOp.Read(ctx, types.StringID(gslb.Id))
+	if err != nil {
+		return err
+	}
+
+	// バリデーション済み
+	shouldUpdate := false
+	for _, s := range current.DestinationServers {
+		for _, nic := range server.AssignedNetwork {
+			if s.IPAddress == nic.IpAddress {
+				s.Enabled = types.StringFlag(attach)
+				shouldUpdate = true
+
+				if err := sender.Send(&handler.HandleResponse{
+					ScalingJobId: jobID,
+					Status:       handler.HandleResponse_RUNNING,
+					Log:          fmt.Sprintf("found target server: %#v", s),
+				}); err != nil {
+					return err
+				}
+
+				break
+			}
+		}
+	}
+
+	if !shouldUpdate {
+		if err := sender.Send(&handler.HandleResponse{
+			ScalingJobId: jobID,
+			Status:       handler.HandleResponse_DONE,
+			Log:          "target server not found",
+		}); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	if _, err := gslbOp.UpdateSettings(ctx, types.StringID(gslb.Id), &sacloud.GSLBUpdateSettingsRequest{
+		HealthCheck:        current.HealthCheck,
+		DelayLoop:          current.DelayLoop,
+		Weighted:           current.Weighted,
+		SorryServer:        current.SorryServer,
+		DestinationServers: current.DestinationServers,
+		SettingsHash:       current.SettingsHash,
+	}); err != nil {
+		return err
+	}
+
+	return sender.Send(&handler.HandleResponse{
+		ScalingJobId: jobID,
+		Status:       handler.HandleResponse_DONE,
+	})
+}


### PR DESCRIPTION
closes #38 

サーバの垂直スケール時のPreHandle/PostHandleでGSLBからのデタッチ/アタッチを行うハンドラーを追加する。
ELBの場合と同じく、デタッチ/アタッチはGSLBのサーバが持つ`Enalbed`フィールドを設定することで行う。
