### PR TITLE
Validate input parameters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sacloud/autoscaler
 go 1.16
 
 require (
+	github.com/go-playground/validator/v10 v10.4.1
 	github.com/goccy/go-yaml v1.8.9
 	github.com/sacloud/libsacloud/v2 v2.18.1
 	github.com/spf13/cobra v1.1.3

--- a/inputs/inputs.go
+++ b/inputs/inputs.go
@@ -101,11 +101,13 @@ func (s *server) handle(requestType string, w http.ResponseWriter, req *http.Req
 
 	scalingReq, err := s.parseRequest(requestType, req)
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error())) // nolint
 		return
 	}
 	if scalingReq == nil {
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ignored")) // nolint
 		return
 	}
 
@@ -116,7 +118,7 @@ func (s *server) handle(requestType string, w http.ResponseWriter, req *http.Req
 	}
 
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("ok")) // nolint
+	w.Write([]byte("accepted")) // nolint
 }
 
 func (s *server) parseRequest(requestType string, req *http.Request) (*ScalingRequest, error) {

--- a/inputs/inputs.go
+++ b/inputs/inputs.go
@@ -28,6 +28,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+var webhookBodyMaxLen = int64(64 * 1024) // 64KB
+
 type Input interface {
 	Name() string
 	Version() string
@@ -94,6 +96,9 @@ func (s *server) listenAndServe() error {
 }
 
 func (s *server) handle(requestType string, w http.ResponseWriter, req *http.Request) {
+	// bodyをwebhookBodyMaxLenまでに制限
+	req.Body = http.MaxBytesReader(w, req.Body, webhookBodyMaxLen)
+
 	scalingReq, err := s.parseRequest(requestType, req)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -114,7 +119,7 @@ func (s *server) handle(requestType string, w http.ResponseWriter, req *http.Req
 	w.Write([]byte("ok")) // nolint
 }
 
-func (s *server) parseRequest(requestType string, req *http.Request) (*scalingRequest, error) {
+func (s *server) parseRequest(requestType string, req *http.Request) (*ScalingRequest, error) {
 	log.Println("webhook received")
 	if s.debug {
 		dump, err := httputil.DumpRequest(req, true)
@@ -133,7 +138,6 @@ func (s *server) parseRequest(requestType string, req *http.Request) (*scalingRe
 		return nil, nil
 	}
 
-	// TODO 外部からの入力となるため厳しめのバリデーションを実装する
 	queryStrings := req.URL.Query()
 	source := queryStrings.Get("source")
 	if source == "" {
@@ -143,25 +147,29 @@ func (s *server) parseRequest(requestType string, req *http.Request) (*scalingRe
 	if action == "" {
 		action = defaults.ActionName
 	}
-	groupName := queryStrings.Get("resource_group_name")
+	groupName := queryStrings.Get("resource-group-name")
 	if groupName == "" {
 		groupName = defaults.ResourceGroupName
 	}
-	desiredStateName := queryStrings.Get("desired_state_name")
+	desiredStateName := queryStrings.Get("desired-state-name")
 	if desiredStateName == "" {
 		desiredStateName = defaults.DesiredStateName
 	}
 
-	return &scalingRequest{
-		source:           source,
-		action:           action,
-		groupName:        groupName,
-		requestType:      requestType,
-		desiredStateName: desiredStateName,
-	}, nil
+	scalingReq := &ScalingRequest{
+		Source:           source,
+		Action:           action,
+		GroupName:        groupName,
+		RequestType:      requestType,
+		DesiredStateName: desiredStateName,
+	}
+	if err := scalingReq.Validate(); err != nil {
+		return nil, err
+	}
+	return scalingReq, nil
 }
 
-func (s *server) send(scalingReq *scalingRequest) error {
+func (s *server) send(scalingReq *ScalingRequest) error {
 	if scalingReq == nil {
 		return nil
 	}
@@ -177,31 +185,23 @@ func (s *server) send(scalingReq *scalingRequest) error {
 	req := request.NewScalingServiceClient(conn)
 	var f func(ctx context.Context, in *request.ScalingRequest, opts ...grpc.CallOption) (*request.ScalingResponse, error)
 
-	switch scalingReq.requestType {
+	switch scalingReq.RequestType {
 	case "up":
 		f = req.Up
 	case "down":
 		f = req.Down
 	default:
-		return fmt.Errorf("invalid request type: %s", scalingReq.requestType)
+		return fmt.Errorf("invalid request type: %s", scalingReq.RequestType)
 	}
 	res, err := f(ctx, &request.ScalingRequest{
-		Source:            scalingReq.source,
-		Action:            scalingReq.action,
-		ResourceGroupName: scalingReq.groupName,
-		DesiredStateName:  scalingReq.desiredStateName,
+		Source:            scalingReq.Source,
+		Action:            scalingReq.Action,
+		ResourceGroupName: scalingReq.GroupName,
+		DesiredStateName:  scalingReq.DesiredStateName,
 	})
 	if err != nil {
 		return err
 	}
 	fmt.Printf("status: %s, job-id: %s\n", res.Status, res.ScalingJobId)
 	return nil
-}
-
-type scalingRequest struct {
-	source           string
-	action           string
-	groupName        string
-	requestType      string
-	desiredStateName string
 }

--- a/inputs/request.go
+++ b/inputs/request.go
@@ -1,0 +1,48 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inputs
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// ScalingRequest Inputsからのリクエストを表す
+type ScalingRequest struct {
+	Source           string `name:"source" validate:"omitempty,printascii,max=1024"`
+	Action           string `name:"action" validate:"omitempty,printascii,max=1024"`
+	GroupName        string `name:"resource-group-name" validate:"omitempty,printascii,max=1024"`
+	RequestType      string `name:"request-type" validate:"required,oneof=up down"`
+	DesiredStateName string `name:"desired-state-name" validate:"omitempty,printascii,max=1024"`
+}
+
+func (r *ScalingRequest) Validate() error {
+	validate := r.newValidator()
+	return validate.Struct(r)
+}
+
+func (r *ScalingRequest) newValidator() *validator.Validate {
+	validate := validator.New()
+	validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
+		name := strings.SplitN(fld.Tag.Get("name"), ",", 2)[0]
+		if name == "-" {
+			return ""
+		}
+		return name
+	})
+	return validate
+}

--- a/inputs/request_test.go
+++ b/inputs/request_test.go
@@ -1,0 +1,131 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inputs
+
+import "testing"
+
+func TestScalingRequest_Validate(t *testing.T) {
+	webhookBodyMaxLen = 1
+
+	type fields struct {
+		Source           string
+		Action           string
+		GroupName        string
+		RequestType      string
+		DesiredStateName string
+	}
+	tests := []struct {
+		name    string
+		maxLen  int
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "no error",
+			fields: fields{
+				Source:           "1",
+				Action:           "1",
+				GroupName:        "1",
+				RequestType:      "up",
+				DesiredStateName: "1",
+			},
+			maxLen:  1,
+			wantErr: false,
+		},
+		{
+			name: "source",
+			fields: fields{
+				Source: "12",
+			},
+			maxLen:  1,
+			wantErr: true,
+		},
+		{
+			name: "action",
+			fields: fields{
+				Action: "12",
+			},
+			maxLen:  1,
+			wantErr: true,
+		},
+		{
+			name: "group name",
+			fields: fields{
+				GroupName: "12",
+			},
+			maxLen:  1,
+			wantErr: true,
+		},
+		{
+			name: "desired state name",
+			fields: fields{
+				DesiredStateName: "12",
+			},
+			maxLen:  1,
+			wantErr: true,
+		},
+		{
+			name: "request type",
+			fields: fields{
+				RequestType: "foo",
+			},
+			maxLen:  1,
+			wantErr: true,
+		},
+		{
+			name: "invalid char: multibyte",
+			fields: fields{
+				RequestType: "あ",
+			},
+			maxLen:  1,
+			wantErr: true,
+		},
+		{
+			name: "invalid char: \\n",
+			fields: fields{
+				RequestType: "\n",
+			},
+			maxLen:  1,
+			wantErr: true,
+		},
+		{
+			name: "valid char",
+			fields: fields{
+				Action:           ` !"#%$&'()*+,-./@[\]^_{|}~`,
+				GroupName:        ` !"#%$&'()*+,-./@[\]^_{|}~`,
+				Source:           ` !"#%$&'()*+,-./@[\]^_{|}~`,
+				DesiredStateName: ` !"#%$&'()*+,-./@[\]^_{|}~`,
+				RequestType:      "up",
+			},
+			maxLen:  1024,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &ScalingRequest{
+				Source:           tt.fields.Source,
+				Action:           tt.fields.Action,
+				GroupName:        tt.fields.GroupName,
+				RequestType:      tt.fields.RequestType,
+				DesiredStateName: tt.fields.DesiredStateName,
+			}
+			webhookBodyMaxLen = int64(tt.maxLen)
+			if err := r.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
closes #39 

- Inputsでのパラメータのバリデーション
- バリデーションエラー時にBadRequest(400)を返す
- 処理した結果、無視する場合はOK(200)+Body=`ignored`を返す
- 処理した結果、受け付ける場合はOK(200)+Body=`accepted`を返す