### PR TITLE
Switch logging library from log to go-kit/log

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,4 +31,4 @@ linters:
 
 linters-settings:
   errcheck:
-    ignore: fmt:.*,io:Close
+    ignore: fmt:.*,io:Close,github.com/sacloud/autoscaler/logging:.*

--- a/commands/flags/global_flags.go
+++ b/commands/flags/global_flags.go
@@ -1,0 +1,58 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flags
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sacloud/autoscaler/log"
+
+	"github.com/sacloud/autoscaler/validate"
+	"github.com/spf13/cobra"
+)
+
+type flags struct {
+	LogLevel  string `name:"log-level" validate:"required,oneof=error warn info debug"`
+	LogFormat string `name:"log-format" validate:"required,oneof=logfmt json"`
+}
+
+var global = &flags{
+	LogLevel:  "info",
+	LogFormat: "logfmt",
+}
+
+func SetFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVarP(&global.LogLevel, "log-level", "", global.LogLevel, "Level of logging to be output. options: [ error | warn | info | debug ]")
+	cmd.PersistentFlags().StringVarP(&global.LogFormat, "log-format", "", global.LogFormat, "Format of logging to be output. options: [ logfmt | json ]")
+}
+
+func ValidateFlags(cmd *cobra.Command, args []string) error {
+	err := validate.Struct(global)
+	if err != nil {
+		fmt.Println(err)
+	}
+	return err
+}
+
+func NewLogger() *log.Logger {
+	return log.NewLogger(&log.LoggerOption{
+		Writer:    os.Stderr,
+		JSON:      global.LogFormat == "json",
+		TimeStamp: true,
+		Caller:    false,
+		Level:     log.Level(global.LogLevel),
+	})
+}

--- a/commands/inputs/alertmanager/cmd.go
+++ b/commands/inputs/alertmanager/cmd.go
@@ -15,6 +15,8 @@
 package alertmanager
 
 import (
+	"github.com/sacloud/autoscaler/commands/flags"
+	"github.com/sacloud/autoscaler/defaults"
 	"github.com/sacloud/autoscaler/inputs"
 	"github.com/sacloud/autoscaler/inputs/alertmanager"
 	"github.com/spf13/cobra"
@@ -26,12 +28,16 @@ var Command = &cobra.Command{
 	RunE:  run,
 }
 
-var server = &alertmanager.Input{}
+var (
+	dest    string
+	address string
+)
 
 func init() {
-	inputs.Init(Command, server)
+	Command.Flags().StringVarP(&dest, "dest", "", defaults.CoreSocketAddr, "URL of gRPC endpoint of AutoScaler Core")
+	Command.Flags().StringVarP(&address, "addr", "", ":3001", "the TCP address for the server to listen on")
 }
 
 func run(cmd *cobra.Command, args []string) error {
-	return inputs.Serve(server)
+	return inputs.Serve(alertmanager.NewInput(dest, address, flags.NewLogger()))
 }

--- a/commands/inputs/direct/cmd.go
+++ b/commands/inputs/direct/cmd.go
@@ -79,6 +79,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// 単発の出力のためlog(標準エラー)ではなく標準出力に書く
 	fmt.Printf("status: %s, job-id: %s", res.Status, res.ScalingJobId)
 	if res.Message != "" {
 		fmt.Printf(", message: %s", res.Message)

--- a/commands/inputs/grafana/cmd.go
+++ b/commands/inputs/grafana/cmd.go
@@ -15,6 +15,8 @@
 package grafana
 
 import (
+	"github.com/sacloud/autoscaler/commands/flags"
+	"github.com/sacloud/autoscaler/defaults"
 	"github.com/sacloud/autoscaler/inputs"
 	"github.com/sacloud/autoscaler/inputs/grafana"
 	"github.com/spf13/cobra"
@@ -26,12 +28,16 @@ var Command = &cobra.Command{
 	RunE:  run,
 }
 
-var server = &grafana.Input{}
+var (
+	dest    string
+	address string
+)
 
 func init() {
-	inputs.Init(Command, server)
+	Command.Flags().StringVarP(&dest, "dest", "", defaults.CoreSocketAddr, "URL of gRPC endpoint of AutoScaler Core")
+	Command.Flags().StringVarP(&address, "addr", "", ":3001", "the TCP address for the server to listen on")
 }
 
 func run(cmd *cobra.Command, args []string) error {
-	return inputs.Serve(server)
+	return inputs.Serve(grafana.NewInput(dest, address, flags.NewLogger()))
 }

--- a/commands/root.go
+++ b/commands/root.go
@@ -18,6 +18,7 @@ import (
 	"os"
 
 	"github.com/sacloud/autoscaler/commands/completion"
+	"github.com/sacloud/autoscaler/commands/flags"
 	"github.com/sacloud/autoscaler/commands/inputs"
 	"github.com/sacloud/autoscaler/commands/server"
 	"github.com/sacloud/autoscaler/commands/version"
@@ -25,10 +26,11 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:           "autoscaler",
-	Short:         "autoscaler is a tool for managing the scale of resources on SAKURA cloud",
-	SilenceUsage:  true,
-	SilenceErrors: false,
+	Use:               "autoscaler",
+	Short:             "autoscaler is a tool for managing the scale of resources on SAKURA cloud",
+	PersistentPreRunE: flags.ValidateFlags,
+	SilenceUsage:      true,
+	SilenceErrors:     false,
 }
 
 var subCommands = []*cobra.Command{
@@ -39,6 +41,7 @@ var subCommands = []*cobra.Command{
 }
 
 func init() {
+	flags.SetFlags(rootCmd)
 	rootCmd.AddCommand(subCommands...)
 }
 

--- a/commands/server/start/cmd.go
+++ b/commands/server/start/cmd.go
@@ -19,6 +19,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/sacloud/autoscaler/commands/flags"
 	"github.com/sacloud/autoscaler/core"
 	"github.com/sacloud/autoscaler/defaults"
 	"github.com/spf13/cobra"
@@ -40,6 +41,6 @@ var Command = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 		defer stop()
-		return core.Start(ctx, configPath)
+		return core.Start(ctx, configPath, flags.NewLogger())
 	},
 }

--- a/core/config.go
+++ b/core/config.go
@@ -106,8 +106,8 @@ func (c *Config) APIClient() sacloud.APICaller {
 
 // TODO Validateの実装
 
-func (c *Config) Handlers() Handlers {
-	return append(BuiltinHandlers, c.CustomHandlers...)
+func (c *Config) Handlers(ctx *Context) Handlers {
+	return append(BuiltinHandlers(ctx), c.CustomHandlers...)
 }
 
 // AutoScalerConfig オートスケーラー自体の動作設定

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -17,6 +17,8 @@ package core
 import (
 	"os"
 
+	"github.com/sacloud/autoscaler/log"
+
 	"github.com/sacloud/libsacloud/v2/helper/api"
 )
 
@@ -29,5 +31,12 @@ var (
 		TraceAPI:          os.Getenv("SAKURACLOUD_TRACE") != "",
 		TraceHTTP:         os.Getenv("SAKURACLOUD_TRACE") != "",
 		FakeMode:          true,
+	})
+	testLogger = log.NewLogger(&log.LoggerOption{
+		Writer:    os.Stderr,
+		JSON:      false,
+		TimeStamp: true,
+		Caller:    true,
+		Level:     log.LevelDebug,
 	})
 )

--- a/core/handling_context.go
+++ b/core/handling_context.go
@@ -31,6 +31,12 @@ func NewHandlingContext(parent *Context, computed Computed) *HandlingContext {
 	}
 }
 
+func (c *HandlingContext) WithLogger(keyvals ...interface{}) *HandlingContext {
+	ctx := NewHandlingContext(c.Context, c.cachedComputed)
+	ctx.logger = ctx.logger.With(keyvals...)
+	return ctx
+}
+
 // CurrentComputed 現在処理中の[]Computedを返す
 func (c *HandlingContext) CurrentComputed() Computed {
 	return c.cachedComputed

--- a/core/resource_server_test.go
+++ b/core/resource_server_test.go
@@ -48,7 +48,7 @@ func testContext() *Context {
 		source:            "default",
 		action:            "default",
 		resourceGroupName: "web",
-	})
+	}, testLogger)
 }
 
 func initTestServer(t *testing.T) func() {

--- a/core/service.go
+++ b/core/service.go
@@ -16,7 +16,6 @@ package core
 
 import (
 	"context"
-	"log"
 
 	"github.com/sacloud/autoscaler/request"
 )
@@ -33,7 +32,9 @@ func NewScalingService(instance *Core) request.ScalingServiceServer {
 }
 
 func (s *ScalingService) Up(ctx context.Context, req *request.ScalingRequest) (*request.ScalingResponse, error) {
-	log.Println("Core.ScalingService: Up:", req)
+	if err := s.instance.logger.Info("message", "Core.ScalingService: Up", "request", req); err != nil {
+		return nil, err
+	}
 
 	// リクエストには即時応答を返しつつバックグラウンドでジョブを実行するために引数のctxは引き継がない
 	serviceCtx := NewContext(context.Background(), &requestInfo{
@@ -42,7 +43,7 @@ func (s *ScalingService) Up(ctx context.Context, req *request.ScalingRequest) (*
 		action:            req.Action,
 		resourceGroupName: req.ResourceGroupName,
 		desiredStateName:  req.DesiredStateName,
-	})
+	}, s.instance.logger)
 	job, message, err := s.instance.Up(serviceCtx)
 	if err != nil {
 		return nil, err
@@ -55,7 +56,9 @@ func (s *ScalingService) Up(ctx context.Context, req *request.ScalingRequest) (*
 }
 
 func (s *ScalingService) Down(ctx context.Context, req *request.ScalingRequest) (*request.ScalingResponse, error) {
-	log.Println("Core.ScalingService: Down:", req)
+	if err := s.instance.logger.Info("message", "Core.ScalingService: Down", "request", req.String()); err != nil {
+		return nil, err
+	}
 
 	// リクエストには即時応答を返しつつバックグラウンドでジョブを実行するために引数のctxは引き継がない
 	serviceCtx := NewContext(context.Background(), &requestInfo{
@@ -64,7 +67,7 @@ func (s *ScalingService) Down(ctx context.Context, req *request.ScalingRequest) 
 		action:            req.Action,
 		resourceGroupName: req.ResourceGroupName,
 		desiredStateName:  req.DesiredStateName,
-	})
+	}, s.instance.logger)
 	job, message, err := s.instance.Down(serviceCtx)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sacloud/autoscaler
 go 1.16
 
 require (
+	github.com/go-kit/log v0.1.0
 	github.com/go-playground/validator/v10 v10.4.1
 	github.com/goccy/go-yaml v1.8.9
 	github.com/sacloud/libsacloud/v2 v2.18.1

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,12 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
+github.com/go-kit/log v0.1.0 h1:DGJh0Sm43HbOeYDNnVZFl8BvcYVvjD5bqYJvp0REbwQ=
+github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=
+github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
@@ -98,6 +102,7 @@ github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7aM3F26W0hOn+GE=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
+github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/goccy/go-yaml v1.8.9 h1:4AEXg2qx+/w29jXnXpMY6mTckmYu1TMoHteKuMf0HFg=
 github.com/goccy/go-yaml v1.8.9/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=

--- a/handlers/builtins/handler.go
+++ b/handlers/builtins/handler.go
@@ -15,10 +15,9 @@
 package builtins
 
 import (
-	"log"
-
 	"github.com/sacloud/autoscaler/handler"
 	"github.com/sacloud/autoscaler/handlers"
+	"github.com/sacloud/autoscaler/log"
 )
 
 // Handler builtinハンドラーをラップし、リクエスト受付時のログ出力を担当するハンドラー
@@ -36,32 +35,39 @@ func (h *Handler) Version() string {
 	return h.Builtin.Version()
 }
 
+func (h *Handler) GetLogger() *log.Logger {
+	return h.Builtin.GetLogger()
+}
+
 func (h *Handler) PreHandle(req *handler.PreHandleRequest, sender handlers.ResponseSender) error {
 	if builtin, ok := h.Builtin.(handlers.PreHandler); ok {
-		log.Printf("%s: PreHandle request received: %s", handlers.HandlerFullName(h.Builtin), req.String())
+		if err := h.GetLogger().Info("message", "PreHandle request received", "request", req.String()); err != nil {
+			return err
+		}
 		return builtin.PreHandle(req, sender)
 	}
 
-	log.Printf("%s: PreHandle request ignored: %s", handlers.HandlerFullName(h.Builtin), req.String())
-	return nil
+	return h.GetLogger().Info("message", "PreHandle request ignored", "request", req.String())
 }
 
 func (h *Handler) Handle(req *handler.HandleRequest, sender handlers.ResponseSender) error {
 	if builtin, ok := h.Builtin.(handlers.Handler); ok {
-		log.Printf("%s: Handle request received: %s", handlers.HandlerFullName(h.Builtin), req.String())
+		if err := h.GetLogger().Info("message", "Handle request received", "request", req.String()); err != nil {
+			return err
+		}
 		return builtin.Handle(req, sender)
 	}
 
-	log.Printf("%s: Handle request ignored: %s", handlers.HandlerFullName(h.Builtin), req.String())
-	return nil
+	return h.GetLogger().Info("message", "Handle request ignored", "request", req.String())
 }
 
 func (h *Handler) PostHandle(req *handler.PostHandleRequest, sender handlers.ResponseSender) error {
 	if builtin, ok := h.Builtin.(handlers.PostHandler); ok {
-		log.Printf("%s: PostHandle request received: %s", handlers.HandlerFullName(h.Builtin), req.String())
+		if err := h.GetLogger().Info("message", "PostHandle request received", "request", req.String()); err != nil {
+			return err
+		}
 		return builtin.PostHandle(req, sender)
 	}
 
-	log.Printf("%s: PostHandle request ignored: %s", handlers.HandlerFullName(h.Builtin), req.String())
-	return nil
+	return h.GetLogger().Info("message", "PostHandle request ignored", "request", req.String())
 }

--- a/handlers/elb/servers_handler.go
+++ b/handlers/elb/servers_handler.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sacloud/autoscaler/handler"
 	"github.com/sacloud/autoscaler/handlers"
+	"github.com/sacloud/autoscaler/log"
 	"github.com/sacloud/autoscaler/version"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -36,6 +37,7 @@ import (
 // もしELBにサーバが1台しか登録されていない場合はサービス停止が発生するため注意が必要
 type ServersHandler struct {
 	handlers.SakuraCloudFlagCustomizer
+	Logger *log.Logger
 }
 
 func (h *ServersHandler) Name() string {
@@ -44,6 +46,10 @@ func (h *ServersHandler) Name() string {
 
 func (h *ServersHandler) Version() string {
 	return version.FullVersion()
+}
+
+func (h *ServersHandler) GetLogger() *log.Logger {
+	return h.Logger
 }
 
 func (h *ServersHandler) PreHandle(req *handler.PreHandleRequest, sender handlers.ResponseSender) error {

--- a/handlers/elb/vertical_scale_handler.go
+++ b/handlers/elb/vertical_scale_handler.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sacloud/autoscaler/handler"
 	"github.com/sacloud/autoscaler/handlers"
+	"github.com/sacloud/autoscaler/log"
 	"github.com/sacloud/autoscaler/version"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -27,6 +28,7 @@ import (
 
 type VerticalScaleHandler struct {
 	handlers.SakuraCloudFlagCustomizer
+	Logger *log.Logger
 }
 
 func (h *VerticalScaleHandler) Name() string {
@@ -35,6 +37,10 @@ func (h *VerticalScaleHandler) Name() string {
 
 func (h *VerticalScaleHandler) Version() string {
 	return version.FullVersion()
+}
+
+func (h *VerticalScaleHandler) GetLogger() *log.Logger {
+	return h.Logger
 }
 
 func (h *VerticalScaleHandler) Handle(req *handler.HandleRequest, sender handlers.ResponseSender) error {

--- a/handlers/fake/handler.go
+++ b/handlers/fake/handler.go
@@ -19,10 +19,13 @@ import (
 
 	"github.com/sacloud/autoscaler/handler"
 	"github.com/sacloud/autoscaler/handlers"
+	"github.com/sacloud/autoscaler/log"
 	"github.com/sacloud/autoscaler/version"
 )
 
-type Handler struct{}
+type Handler struct {
+	Logger *log.Logger
+}
 
 func (h *Handler) Name() string {
 	return "fake"
@@ -30,6 +33,10 @@ func (h *Handler) Name() string {
 
 func (h *Handler) Version() string {
 	return version.FullVersion()
+}
+
+func (h *Handler) GetLogger() *log.Logger {
+	return h.Logger
 }
 
 func (h *Handler) Handle(req *handler.HandleRequest, sender handlers.ResponseSender) error {

--- a/handlers/gslb/servers_handler.go
+++ b/handlers/gslb/servers_handler.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sacloud/autoscaler/handler"
 	"github.com/sacloud/autoscaler/handlers"
+	"github.com/sacloud/autoscaler/log"
 	"github.com/sacloud/autoscaler/version"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -36,6 +37,7 @@ import (
 // もしGSLBにサーバが1台しか登録されていない場合はサービス停止が発生するため注意が必要
 type ServersHandler struct {
 	handlers.SakuraCloudFlagCustomizer
+	Logger *log.Logger
 }
 
 func (h *ServersHandler) Name() string {
@@ -44,6 +46,10 @@ func (h *ServersHandler) Name() string {
 
 func (h *ServersHandler) Version() string {
 	return version.FullVersion()
+}
+
+func (h *ServersHandler) GetLogger() *log.Logger {
+	return h.Logger
 }
 
 func (h *ServersHandler) PreHandle(req *handler.PreHandleRequest, sender handlers.ResponseSender) error {

--- a/handlers/router/vertical_scale_handler.go
+++ b/handlers/router/vertical_scale_handler.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sacloud/autoscaler/handler"
 	"github.com/sacloud/autoscaler/handlers"
+	"github.com/sacloud/autoscaler/log"
 	"github.com/sacloud/autoscaler/version"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -27,6 +28,7 @@ import (
 
 type VerticalScaleHandler struct {
 	handlers.SakuraCloudFlagCustomizer
+	Logger *log.Logger
 }
 
 func (h *VerticalScaleHandler) Name() string {
@@ -35,6 +37,10 @@ func (h *VerticalScaleHandler) Name() string {
 
 func (h *VerticalScaleHandler) Version() string {
 	return version.FullVersion()
+}
+
+func (h *VerticalScaleHandler) GetLogger() *log.Logger {
+	return h.Logger
 }
 
 func (h *VerticalScaleHandler) Handle(req *handler.HandleRequest, sender handlers.ResponseSender) error {

--- a/handlers/server/vertical_scale_handler.go
+++ b/handlers/server/vertical_scale_handler.go
@@ -18,11 +18,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/sacloud/libsacloud/v2/helper/power"
-
 	"github.com/sacloud/autoscaler/handler"
 	"github.com/sacloud/autoscaler/handlers"
+	"github.com/sacloud/autoscaler/log"
 	"github.com/sacloud/autoscaler/version"
+	"github.com/sacloud/libsacloud/v2/helper/power"
 	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -30,6 +30,7 @@ import (
 
 type VerticalScaleHandler struct {
 	handlers.SakuraCloudFlagCustomizer
+	Logger *log.Logger
 }
 
 func (h *VerticalScaleHandler) Name() string {
@@ -38,6 +39,10 @@ func (h *VerticalScaleHandler) Name() string {
 
 func (h *VerticalScaleHandler) Version() string {
 	return version.FullVersion()
+}
+
+func (h *VerticalScaleHandler) GetLogger() *log.Logger {
+	return h.Logger
 }
 
 func (h *VerticalScaleHandler) Handle(req *handler.HandleRequest, sender handlers.ResponseSender) error {

--- a/handlers/stub/handler.go
+++ b/handlers/stub/handler.go
@@ -15,8 +15,11 @@
 package stub
 
 import (
+	"os"
+
 	"github.com/sacloud/autoscaler/handler"
 	"github.com/sacloud/autoscaler/handlers"
+	"github.com/sacloud/autoscaler/log"
 	"github.com/sacloud/autoscaler/version"
 )
 
@@ -25,6 +28,7 @@ type Handler struct {
 	PreHandleFunc  func(*handler.PreHandleRequest, handlers.ResponseSender) error
 	HandleFunc     func(*handler.HandleRequest, handlers.ResponseSender) error
 	PostHandleFunc func(*handler.PostHandleRequest, handlers.ResponseSender) error
+	Logger         *log.Logger
 }
 
 func (h *Handler) Name() string {
@@ -33,6 +37,19 @@ func (h *Handler) Name() string {
 
 func (h *Handler) Version() string {
 	return version.FullVersion()
+}
+
+func (h *Handler) GetLogger() *log.Logger {
+	if h.Logger != nil {
+		return h.Logger
+	}
+	return log.NewLogger(&log.LoggerOption{
+		Writer:    os.Stderr,
+		JSON:      false,
+		TimeStamp: true,
+		Caller:    true,
+		Level:     log.LevelDebug,
+	})
 }
 
 func (h *Handler) PreHandle(req *handler.PreHandleRequest, sender handlers.ResponseSender) error {

--- a/inputs/alertmanager/input.go
+++ b/inputs/alertmanager/input.go
@@ -19,10 +19,23 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/sacloud/autoscaler/log"
 	"github.com/sacloud/autoscaler/version"
 )
 
-type Input struct{}
+type Input struct {
+	dest   string
+	addr   string
+	logger *log.Logger
+}
+
+func NewInput(dest, addr string, logger *log.Logger) *Input {
+	return &Input{
+		dest:   dest,
+		addr:   addr,
+		logger: logger,
+	}
+}
 
 func (in *Input) Name() string {
 	return "alertmanager"
@@ -30,6 +43,18 @@ func (in *Input) Name() string {
 
 func (in *Input) Version() string {
 	return version.FullVersion()
+}
+
+func (in *Input) Destination() string {
+	return in.dest
+}
+
+func (in *Input) ListenAddress() string {
+	return in.addr
+}
+
+func (in *Input) GetLogger() *log.Logger {
+	return in.logger
 }
 
 func (in *Input) ShouldAccept(req *http.Request) (bool, error) {

--- a/inputs/grafana/input.go
+++ b/inputs/grafana/input.go
@@ -19,17 +19,41 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/sacloud/autoscaler/log"
 	"github.com/sacloud/autoscaler/version"
 )
 
-type Input struct{}
+type Input struct {
+	dest   string
+	addr   string
+	logger *log.Logger
+}
 
+func NewInput(dest, addr string, logger *log.Logger) *Input {
+	return &Input{
+		dest:   dest,
+		addr:   addr,
+		logger: logger,
+	}
+}
 func (in *Input) Name() string {
 	return "grafana"
 }
 
 func (in *Input) Version() string {
 	return version.FullVersion()
+}
+
+func (in *Input) Destination() string {
+	return in.dest
+}
+
+func (in *Input) ListenAddress() string {
+	return in.addr
+}
+
+func (in *Input) GetLogger() *log.Logger {
+	return in.logger
 }
 
 func (in *Input) ShouldAccept(req *http.Request) (bool, error) {

--- a/inputs/inputs.go
+++ b/inputs/inputs.go
@@ -204,6 +204,7 @@ func (s *server) send(scalingReq *ScalingRequest) error {
 	if err != nil {
 		return err
 	}
+	// TODO logに出力
 	fmt.Printf("status: %s, job-id: %s\n", res.Status, res.ScalingJobId)
 	return nil
 }

--- a/inputs/inputs.go
+++ b/inputs/inputs.go
@@ -17,14 +17,12 @@ package inputs
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httputil"
 
 	"github.com/sacloud/autoscaler/defaults"
+	"github.com/sacloud/autoscaler/log"
 	"github.com/sacloud/autoscaler/request"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 )
 
@@ -34,38 +32,21 @@ type Input interface {
 	Name() string
 	Version() string
 	ShouldAccept(req *http.Request) (bool, error) // true,nilを返した場合のみCoreへのリクエストを行う
-}
-
-type FlagCustomizer interface {
-	CustomizeFlags(fs *pflag.FlagSet)
+	Destination() string
+	ListenAddress() string
+	GetLogger() *log.Logger
 }
 
 func FullName(input Input) string {
 	return fmt.Sprintf("autoscaler-inputs-%s", input.Name())
 }
 
-var (
-	dest    string
-	address string
-	debug   bool
-)
-
-func Init(cmd *cobra.Command, input Input) {
-	cmd.Flags().StringVarP(&dest, "dest", "", defaults.CoreSocketAddr, "URL of gRPC endpoint of AutoScaler Core")
-	cmd.Flags().StringVarP(&address, "addr", "", ":3001", "the TCP address for the server to listen on")
-	cmd.Flags().BoolVarP(&debug, "debug", "", false, "Show debug logs")
-	// 各Handlerでのカスタマイズ
-	if fc, ok := input.(FlagCustomizer); ok {
-		fc.CustomizeFlags(cmd.Flags())
-	}
-}
-
 func Serve(input Input) error {
 	server := &server{
-		coreAddress:   dest,
-		listenAddress: address,
+		coreAddress:   input.Destination(),
+		listenAddress: input.ListenAddress(),
 		input:         input,
-		debug:         debug,
+		logger:        input.GetLogger().WithPrefix("from", FullName(input)),
 	}
 	return server.listenAndServe()
 }
@@ -74,7 +55,7 @@ type server struct {
 	coreAddress   string
 	listenAddress string
 	input         Input
-	debug         bool
+	logger        *log.Logger
 }
 
 func (s *server) listenAndServe() error {
@@ -91,7 +72,10 @@ func (s *server) listenAndServe() error {
 		w.Write([]byte("ok")) // nolint
 	})
 
-	log.Printf("%s: started on %s\n", FullName(s.input), s.listenAddress)
+	if err := s.logger.Info("message", "started", "address", s.listenAddress); err != nil {
+		return err
+	}
+
 	return http.ListenAndServe(s.listenAddress, serveMux)
 }
 
@@ -112,7 +96,7 @@ func (s *server) handle(requestType string, w http.ResponseWriter, req *http.Req
 	}
 
 	if err := s.send(scalingReq); err != nil {
-		log.Println("[ERROR]: ", err)
+		s.logger.Error("error", err) // nolint
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -122,13 +106,16 @@ func (s *server) handle(requestType string, w http.ResponseWriter, req *http.Req
 }
 
 func (s *server) parseRequest(requestType string, req *http.Request) (*ScalingRequest, error) {
-	log.Println("webhook received")
-	if s.debug {
-		dump, err := httputil.DumpRequest(req, true)
-		if err != nil {
-			return nil, err
-		}
-		log.Println(string(dump))
+	if err := s.logger.Info("message", "webhook received"); err != nil {
+		return nil, err
+	}
+
+	dump, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.logger.Debug("request", string(dump)); err != nil {
+		return nil, err
 	}
 
 	shouldAccept, err := s.input.ShouldAccept(req)
@@ -136,7 +123,9 @@ func (s *server) parseRequest(requestType string, req *http.Request) (*ScalingRe
 		return nil, err
 	}
 	if !shouldAccept {
-		log.Println("webhook ignored")
+		if err := s.logger.Info("message", "webhook ignored"); err != nil {
+			return nil, err
+		}
 		return nil, nil
 	}
 
@@ -204,7 +193,5 @@ func (s *server) send(scalingReq *ScalingRequest) error {
 	if err != nil {
 		return err
 	}
-	// TODO logに出力
-	fmt.Printf("status: %s, job-id: %s\n", res.Status, res.ScalingJobId)
-	return nil
+	return s.logger.Info("message", "webhook handled", "status", res.Status, "job-id", res.ScalingJobId)
 }

--- a/inputs/request.go
+++ b/inputs/request.go
@@ -15,10 +15,7 @@
 package inputs
 
 import (
-	"reflect"
-	"strings"
-
-	"github.com/go-playground/validator/v10"
+	"github.com/sacloud/autoscaler/validate"
 )
 
 // ScalingRequest Inputsからのリクエストを表す
@@ -31,18 +28,5 @@ type ScalingRequest struct {
 }
 
 func (r *ScalingRequest) Validate() error {
-	validate := r.newValidator()
 	return validate.Struct(r)
-}
-
-func (r *ScalingRequest) newValidator() *validator.Validate {
-	validate := validator.New()
-	validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
-		name := strings.SplitN(fld.Tag.Get("name"), ",", 2)[0]
-		if name == "-" {
-			return ""
-		}
-		return name
-	})
-	return validate
 }

--- a/log/logging.go
+++ b/log/logging.go
@@ -30,13 +30,13 @@ type Logger struct {
 }
 
 // Level ログレベル
-type Level int
+type Level string
 
 const (
-	LevelError Level = iota
-	LevelWarn
-	LevelInfo
-	LevelDebug
+	LevelError = Level("error")
+	LevelWarn  = Level("warn")
+	LevelInfo  = Level("info")
+	LevelDebug = Level("debug")
 )
 
 // LoggerOption ログ出力のオプション
@@ -75,7 +75,7 @@ func (l *Logger) initLogger(opt *LoggerOption) {
 	}
 
 	if opt.TimeStamp {
-		logger = log.With(logger, "ts", log.TimestampFormat(time.Now, time.RFC3339))
+		logger = log.With(logger, "timestamp", log.TimestampFormat(time.Now, time.RFC3339))
 	}
 	if opt.Caller {
 		logger = log.With(logger, "caller", log.DefaultCaller)
@@ -108,7 +108,7 @@ func (l *Logger) Reset() {
 // see: https://pkg.go.dev/github.com/go-kit/log
 func (l *Logger) With(keyvals ...interface{}) *Logger {
 	logger := NewLogger(l.opt)
-	logger.internal = log.With(logger.internal, keyvals...)
+	logger.internal = log.With(l.internal, keyvals...)
 	return logger
 }
 
@@ -117,7 +117,7 @@ func (l *Logger) With(keyvals ...interface{}) *Logger {
 // see: https://pkg.go.dev/github.com/go-kit/log
 func (l *Logger) WithPrefix(keyvals ...interface{}) *Logger {
 	logger := NewLogger(l.opt)
-	logger.internal = log.WithPrefix(logger.internal, keyvals...)
+	logger.internal = log.WithPrefix(l.internal, keyvals...)
 	return logger
 }
 
@@ -126,8 +126,13 @@ func (l *Logger) WithPrefix(keyvals ...interface{}) *Logger {
 // see: https://pkg.go.dev/github.com/go-kit/log
 func (l *Logger) WithSuffix(keyvals ...interface{}) *Logger {
 	logger := NewLogger(l.opt)
-	logger.internal = log.WithSuffix(logger.internal, keyvals...)
+	logger.internal = log.WithSuffix(l.internal, keyvals...)
 	return logger
+}
+
+func (l *Logger) Fatal(keyvals ...interface{}) {
+	l.Error(keyvals...) // nolint
+	os.Exit(1)
 }
 
 // Error レベルErrorでログ出力

--- a/log/logging.go
+++ b/log/logging.go
@@ -1,0 +1,151 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"io"
+	"os"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+// Logger ログ出力
+type Logger struct {
+	internal log.Logger
+	opt      *LoggerOption
+}
+
+// Level ログレベル
+type Level int
+
+const (
+	LevelError Level = iota
+	LevelWarn
+	LevelInfo
+	LevelDebug
+)
+
+// LoggerOption ログ出力のオプション
+type LoggerOption struct {
+	Writer    io.Writer // 出力先(デフォルトはos.Stderr)
+	JSON      bool      // JSON出力するか(falseの場合はlogfmt)
+	TimeStamp bool      // タイムスタンプを含めるか
+	Caller    bool      // caller(呼び出し箇所)を含めるか
+	Level     Level     // 出力するログのレベル
+}
+
+// NewLogger 指定のオプションで新しいロガーを生成して返す
+//
+// optは省略(nil)でも可、デフォルトでは標準エラーに出力される
+func NewLogger(opt *LoggerOption) *Logger {
+	if opt == nil {
+		opt = &LoggerOption{}
+	}
+	if opt.Writer == nil {
+		opt.Writer = os.Stderr
+	}
+
+	logger := &Logger{}
+	logger.initLogger(opt)
+	return logger
+}
+
+func (l *Logger) initLogger(opt *LoggerOption) {
+	w := log.NewSyncWriter(opt.Writer)
+	var logger log.Logger
+	switch {
+	case opt.JSON:
+		logger = log.NewJSONLogger(w)
+	default:
+		logger = log.NewLogfmtLogger(w)
+	}
+
+	if opt.TimeStamp {
+		logger = log.With(logger, "ts", log.TimestampFormat(time.Now, time.RFC3339))
+	}
+	if opt.Caller {
+		logger = log.With(logger, "caller", log.DefaultCaller)
+	}
+
+	switch opt.Level {
+	case LevelError:
+		logger = level.NewFilter(logger, level.AllowError())
+	case LevelWarn:
+		logger = level.NewFilter(logger, level.AllowWarn())
+	case LevelInfo:
+		logger = level.NewFilter(logger, level.AllowInfo())
+	case LevelDebug:
+		logger = level.NewFilter(logger, level.AllowDebug())
+	}
+
+	l.internal = logger
+	l.opt = opt
+}
+
+// Reset 現在のLoggerOptionを元にロガーをリセット
+//
+//  Withxxxの影響を元に戻したい時などに利用する
+func (l *Logger) Reset() {
+	l.initLogger(l.opt)
+}
+
+// With 指定されたkey-valuesを持つコンテキストロガーを返す
+//
+// see: https://pkg.go.dev/github.com/go-kit/log
+func (l *Logger) With(keyvals ...interface{}) *Logger {
+	logger := NewLogger(l.opt)
+	logger.internal = log.With(logger.internal, keyvals...)
+	return logger
+}
+
+// WithPrefix 指定されたkey-valuesを持つコンテキストロガーを返す
+//
+// see: https://pkg.go.dev/github.com/go-kit/log
+func (l *Logger) WithPrefix(keyvals ...interface{}) *Logger {
+	logger := NewLogger(l.opt)
+	logger.internal = log.WithPrefix(logger.internal, keyvals...)
+	return logger
+}
+
+// WithSuffix 指定されたkey-valuesを持つコンテキストロガーを返す
+//
+// see: https://pkg.go.dev/github.com/go-kit/log
+func (l *Logger) WithSuffix(keyvals ...interface{}) *Logger {
+	logger := NewLogger(l.opt)
+	logger.internal = log.WithSuffix(logger.internal, keyvals...)
+	return logger
+}
+
+// Error レベルErrorでログ出力
+func (l *Logger) Error(keyvals ...interface{}) error {
+	return level.Error(l.internal).Log(keyvals...)
+}
+
+// Warn レベルWarnでログ出力
+func (l *Logger) Warn(keyvals ...interface{}) error {
+	return level.Warn(l.internal).Log(keyvals...)
+}
+
+// Info レベルInfoでログ出力
+func (l *Logger) Info(keyvals ...interface{}) error {
+	return level.Info(l.internal).Log(keyvals...)
+}
+
+// Debug レベルDebugでログ出力
+func (l *Logger) Debug(keyvals ...interface{}) error {
+	return level.Debug(l.internal).Log(keyvals...)
+}

--- a/log/logging_test.go
+++ b/log/logging_test.go
@@ -1,0 +1,63 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogger_Error(t *testing.T) {
+	buf := bytes.NewBufferString("")
+	logger := NewLogger(&LoggerOption{
+		Writer:    buf,
+		JSON:      false,
+		TimeStamp: false,
+		Caller:    false,
+		Level:     LevelError,
+	})
+
+	logger.Debug("msg", "this value will never be displayed") // nolint
+	logger.Error("msg", "this value will be displayed")       // nolint
+
+	require.Equal(t, `level=error msg="this value will be displayed"`+"\n", buf.String())
+}
+
+func TestLogger_With(t *testing.T) {
+	buf := bytes.NewBufferString("")
+
+	logger := NewLogger(&LoggerOption{
+		Writer:    buf,
+		JSON:      false,
+		TimeStamp: false,
+		Caller:    false,
+		Level:     LevelError,
+	})
+
+	logger.Error("msg", "message without prefix") // nolint
+	logger = logger.With("prefix", "foobar")
+	logger.Error("msg", "message with prefix") // nolint
+
+	expected := []string{
+		`level=error msg="message without prefix"`,
+		`level=error prefix=foobar msg="message with prefix"`,
+		"",
+	}
+
+	require.Equal(t, expected, strings.Split(buf.String(), "\n"))
+}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -12,27 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package logging
+package validate
 
 import (
-	"log"
+	"reflect"
+	"strings"
 
-	"github.com/sacloud/autoscaler/handler"
-	"github.com/sacloud/autoscaler/handlers"
-	"github.com/sacloud/autoscaler/version"
+	"github.com/go-playground/validator/v10"
 )
 
-type Handler struct{}
-
-func (h *Handler) Name() string {
-	return "logging"
-}
-
-func (h *Handler) Version() string {
-	return version.FullVersion()
-}
-
-func (h *Handler) Handle(req *handler.HandleRequest, sender handlers.ResponseSender) error {
-	log.Printf("autoscaler-handlers-%s: received: %s", h.Name(), req.String())
-	return nil
+func Struct(v interface{}) error {
+	validate := validator.New()
+	validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
+		name := strings.SplitN(fld.Tag.Get("name"), ",", 2)[0]
+		if name == "-" {
+			return ""
+		}
+		return name
+	})
+	// TODO エラーメッセージのカスタマイズ
+	return validate.Struct(v)
 }


### PR DESCRIPTION
closes #51 

- go-kit/logを用いたログ出力を行うためのパッケージ`log`を追加
- 各ログ出力箇所をlogパッケージを利用するように修正
- CLIにてログレベル/出力フォーマット(JSON or logfmt)を指定可能に