### PR TITLE
Improve validation error message

### DIFF
--- a/commands/flags/global_flags.go
+++ b/commands/flags/global_flags.go
@@ -15,18 +15,16 @@
 package flags
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/sacloud/autoscaler/log"
-
 	"github.com/sacloud/autoscaler/validate"
 	"github.com/spf13/cobra"
 )
 
 type flags struct {
-	LogLevel  string `name:"log-level" validate:"required,oneof=error warn info debug"`
-	LogFormat string `name:"log-format" validate:"required,oneof=logfmt json"`
+	LogLevel  string `name:"--log-level" validate:"required,oneof=error warn info debug"`
+	LogFormat string `name:"--log-format" validate:"required,oneof=logfmt json"`
 }
 
 var global = &flags{
@@ -40,11 +38,7 @@ func SetFlags(cmd *cobra.Command) {
 }
 
 func ValidateFlags(cmd *cobra.Command, args []string) error {
-	err := validate.Struct(global)
-	if err != nil {
-		fmt.Println(err)
-	}
-	return err
+	return validate.Struct(global)
 }
 
 func NewLogger() *log.Logger {

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/go-kit/log v0.1.0
 	github.com/go-playground/validator/v10 v10.4.1
 	github.com/goccy/go-yaml v1.8.9
+	github.com/hashicorp/go-multierror v1.0.1-0.20190722213833-bdca7bb83f60
 	github.com/sacloud/libsacloud/v2 v2.18.1
 	github.com/spf13/cobra v1.1.3
-	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20210304124612-50617c2ba197 // indirect
 	golang.org/x/text v0.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -169,6 +169,7 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -177,6 +178,7 @@ github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrj
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.0.1-0.20190722213833-bdca7bb83f60 h1:5Ng5F1cIPjTUA2LkeN7w4TDkbJVnlQBLtZiYZLN5lGQ=
 github.com/hashicorp/go-multierror v1.0.1-0.20190722213833-bdca7bb83f60/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-retryablehttp v0.6.4 h1:BbgctKO892xEyOXnGiaAwIoSq1QZ/SS4AhjoAh9DnfY=
 github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=


### PR DESCRIPTION
closes #60 

エラーメッセージを改善する。

コマンドラインでのエラー表示例:

```bash
$ autoscaler server start --log-format foobar
Error: 1 error occurred:
	* --log-format: oneof=logfmt json
```

Inputsでのエラー表示例:

```bash
$ curl -v -d @test.json example.com:3001/up?action=...(1024文字以上)

< HTTP/1.1 400 Bad Request
< Date: Wed, 09 Jun 2021 05:16:52 GMT
< Content-Length: 51
< Content-Type: text/plain; charset=utf-8

1 error occurred:
	* action: max=1024
```