### PR TITLE
Validate CLI flags and Core Configurations

### DIFF
--- a/commands/inputs/alertmanager/cmd.go
+++ b/commands/inputs/alertmanager/cmd.go
@@ -19,25 +19,34 @@ import (
 	"github.com/sacloud/autoscaler/defaults"
 	"github.com/sacloud/autoscaler/inputs"
 	"github.com/sacloud/autoscaler/inputs/alertmanager"
+	"github.com/sacloud/autoscaler/validate"
 	"github.com/spf13/cobra"
 )
 
 var Command = &cobra.Command{
 	Use:   "alertmanager",
 	Short: "Start web server for handle webhooks from AlertManager",
-	RunE:  run,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return validate.Struct(param)
+	},
+	RunE: run,
 }
 
-var (
-	dest    string
-	address string
-)
+type parameter struct {
+	Destination string `name:"--dest" validate:"required"`
+	ListenAddr  string `name:"--addr" validate:"required"`
+}
+
+var param = &parameter{
+	Destination: defaults.CoreSocketAddr,
+	ListenAddr:  ":3001",
+}
 
 func init() {
-	Command.Flags().StringVarP(&dest, "dest", "", defaults.CoreSocketAddr, "URL of gRPC endpoint of AutoScaler Core")
-	Command.Flags().StringVarP(&address, "addr", "", ":3001", "the TCP address for the server to listen on")
+	Command.Flags().StringVarP(&param.Destination, "dest", "", param.Destination, "URL of gRPC endpoint of AutoScaler Core")
+	Command.Flags().StringVarP(&param.ListenAddr, "addr", "", param.ListenAddr, "the TCP address for the server to listen on")
 }
 
 func run(cmd *cobra.Command, args []string) error {
-	return inputs.Serve(alertmanager.NewInput(dest, address, flags.NewLogger()))
+	return inputs.Serve(alertmanager.NewInput(param.Destination, param.ListenAddr, flags.NewLogger()))
 }

--- a/core/actions_test.go
+++ b/core/actions_test.go
@@ -1,0 +1,90 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestActions_Validate(t *testing.T) {
+	type args struct {
+		ctx      context.Context
+		handlers Handlers
+	}
+	tests := []struct {
+		name string
+		a    Actions
+		args args
+		want []error
+	}{
+		{
+			name: "basic",
+			a: Actions{
+				"foobar": []string{"handler1", "handler2"},
+			},
+			args: args{
+				ctx: context.Background(),
+				handlers: Handlers{
+					{Name: "handler1"},
+					{Name: "handler2"},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "not exists",
+			a: Actions{
+				"foobar": []string{"not-exists1", "not-exists2"},
+			},
+			args: args{
+				ctx: context.Background(),
+				handlers: Handlers{
+					{Name: "handler1"},
+					{Name: "handler2"},
+				},
+			},
+			want: []error{
+				fmt.Errorf("handler %q is not defined", "not-exists1"),
+				fmt.Errorf("handler %q is not defined", "not-exists2"),
+			},
+		},
+		{
+			name: "mixed",
+			a: Actions{
+				"foobar": []string{"handler1", "not-exists2", "handler2"},
+			},
+			args: args{
+				ctx: context.Background(),
+				handlers: Handlers{
+					{Name: "handler1"},
+					{Name: "handler2"},
+				},
+			},
+			want: []error{
+				fmt.Errorf("handler %q is not defined", "not-exists2"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.Validate(tt.args.ctx, tt.args.handlers); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Validate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/computed.go
+++ b/core/computed.go
@@ -44,7 +44,7 @@ type ResourcePlan interface {
 	PlanName() string
 	Equals(resource interface{}) bool
 	LessThan(resource interface{}) bool
-	GreaterThan(resource interface{}) bool
+	GreaterThan(resource interface{}) bool // TODO Equals+LessThanがあれば不要なはず
 	LessThanPlan(plans ResourcePlan) bool
 }
 

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestConfig_Load(t *testing.T) {
 	type fields struct {
-		SakuraCloud SakuraCloud
+		SakuraCloud *SakuraCloud
 		Handlers    Handlers
 		Resources   *ResourceGroups
 		AutoScaler  AutoScalerConfig
@@ -41,7 +41,7 @@ func TestConfig_Load(t *testing.T) {
 		{
 			name: "minimal",
 			fields: fields{
-				SakuraCloud: SakuraCloud{
+				SakuraCloud: &SakuraCloud{
 					Credential: Credential{
 						Token:  "token",
 						Secret: "secret",

--- a/core/core.go
+++ b/core/core.go
@@ -29,27 +29,29 @@ import (
 
 // Core AutoScaler Coreのインスタンス
 type Core struct {
-	config *Config
-	jobs   map[string]*JobStatus
-	logger *log.Logger
+	listenAddress string
+	config        *Config
+	jobs          map[string]*JobStatus
+	logger        *log.Logger
 }
 
-func newCoreInstance(c *Config, logger *log.Logger) (*Core, error) {
+func newCoreInstance(addr string, c *Config, logger *log.Logger) (*Core, error) {
 	// TODO バリデーションの実装
 	return &Core{
-		config: c,
-		jobs:   make(map[string]*JobStatus),
-		logger: logger,
+		listenAddress: addr,
+		config:        c,
+		jobs:          make(map[string]*JobStatus),
+		logger:        logger,
 	}, nil
 }
 
-func Start(ctx context.Context, configPath string, logger *log.Logger) error {
+func Start(ctx context.Context, addr, configPath string, logger *log.Logger) error {
 	config, err := NewConfigFromPath(configPath)
 	if err != nil {
 		return err
 	}
 
-	instance, err := newCoreInstance(config, logger)
+	instance, err := newCoreInstance(addr, config, logger)
 	if err != nil {
 		return err
 	}
@@ -61,7 +63,7 @@ func (c *Core) run(ctx context.Context) error {
 	errCh := make(chan error)
 
 	// TODO 簡易的な実装、後ほど整理&切り出し
-	filename := strings.Replace(defaults.CoreSocketAddr, "unix:", "", -1)
+	filename := strings.Replace(c.listenAddress, "unix:", "", -1)
 	lis, err := net.Listen("unix", filename)
 	if err != nil {
 		return fmt.Errorf("starting Core service failed: %s", err)

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -18,20 +18,12 @@ import (
 	"os"
 
 	"github.com/sacloud/autoscaler/log"
-
 	"github.com/sacloud/libsacloud/v2/helper/api"
+	"github.com/sacloud/libsacloud/v2/sacloud"
 )
 
 var (
-	testZone      = "is1a"
-	testAPIClient = api.NewCaller(&api.CallerOptions{
-		AccessToken:       "fake",
-		AccessTokenSecret: "fake",
-		UserAgent:         "sacloud/autoscaler/fake",
-		TraceAPI:          os.Getenv("SAKURACLOUD_TRACE") != "",
-		TraceHTTP:         os.Getenv("SAKURACLOUD_TRACE") != "",
-		FakeMode:          true,
-	})
+	testZone   = "is1a"
 	testLogger = log.NewLogger(&log.LoggerOption{
 		Writer:    os.Stderr,
 		JSON:      false,
@@ -40,3 +32,14 @@ var (
 		Level:     log.LevelDebug,
 	})
 )
+
+func testAPIClient() sacloud.APICaller {
+	return api.NewCaller(&api.CallerOptions{
+		AccessToken:       "fake",
+		AccessTokenSecret: "fake",
+		UserAgent:         "sacloud/autoscaler/fake",
+		TraceAPI:          os.Getenv("SAKURACLOUD_TRACE") != "",
+		TraceHTTP:         os.Getenv("SAKURACLOUD_TRACE") != "",
+		FakeMode:          true,
+	})
+}

--- a/core/handler.go
+++ b/core/handler.go
@@ -29,7 +29,7 @@ import (
 
 type Handlers []*Handler
 
-func BuiltinHandlers(ctx *Context) Handlers {
+func BuiltinHandlers() Handlers {
 	return Handlers{
 		{
 			Type: "elb-vertical-scaler",
@@ -66,13 +66,12 @@ func BuiltinHandlers(ctx *Context) Handlers {
 				Builtin: &server.VerticalScaleHandler{},
 			},
 		},
-		// TODO その他ビルトインを追加
 	}
 }
 
 // Handler カスタムハンドラーの定義
 type Handler struct {
-	Type           string          `yaml:"type"`     // ハンドラー種別 TODO: enumにすべきか要検討
+	Type           string          `yaml:"type"`     // ハンドラー種別
 	Name           string          `yaml:"name"`     // ハンドラーを識別するための名称 同一Typeで複数のハンドラーが存在する場合が存在するため、Nameで一意に識別する
 	Endpoint       string          `yaml:"endpoint"` // カスタムハンドラーの場合にのみ指定
 	BuiltinHandler handlers.Server `yaml:"-"`        // ビルトインハンドラーの場合のみ指定

--- a/core/plan_router.go
+++ b/core/plan_router.go
@@ -18,7 +18,7 @@ import "github.com/sacloud/libsacloud/v2/sacloud"
 
 type RouterPlan struct {
 	Name      string `yaml:"name"`
-	BandWidth int    `yaml:"cps"`
+	BandWidth int    `yaml:"band_width"`
 }
 
 func (p *RouterPlan) PlanName() string {

--- a/core/resource.go
+++ b/core/resource.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -28,7 +29,7 @@ import (
 type Resource interface {
 	Type() ResourceTypes // リソースの型
 	Selector() *ResourceSelector
-	Validate() error
+	Validate(ctx context.Context, apiClient sacloud.APICaller) []error
 
 	// Compute 現在/あるべき姿を算出する
 	//
@@ -57,7 +58,7 @@ type ChildResource interface {
 //
 // Resourceの実装に埋め込む場合、Compute()でComputedCacheを設定すること
 type ResourceBase struct {
-	TypeName       string            `yaml:"type"` // TODO enumにすべきか?
+	TypeName       string            `yaml:"type"`
 	TargetSelector *ResourceSelector `yaml:"selector"`
 	Children       Resources         `yaml:"-"`
 	ComputedCache  Computed          `yaml:"-"`
@@ -76,7 +77,7 @@ func (r *ResourceBase) Type() ResourceTypes {
 	case ResourceTypeDNS.String():
 		return ResourceTypeDNS
 	}
-	return ResourceTypeUnknown // TODO バリデーションなどで到達させないようにする
+	return ResourceTypeUnknown
 }
 
 func (r *ResourceBase) Selector() *ResourceSelector {

--- a/core/resource_group_test.go
+++ b/core/resource_group_test.go
@@ -215,7 +215,7 @@ func TestResourceGroup_handleAll(t *testing.T) {
 			Name: "test",
 		}
 
-		rg.handleAll(testContext(), testAPIClient, Handlers{ // nolint
+		rg.handleAll(testContext(), testAPIClient(), Handlers{ // nolint
 			{
 				Type: "stub",
 				Name: "stub",
@@ -286,7 +286,7 @@ func TestResourceGroup_handleAll(t *testing.T) {
 			Name: "test",
 		}
 
-		rg.handleAll(testContext(), testAPIClient, Handlers{ // nolint
+		rg.handleAll(testContext(), testAPIClient(), Handlers{ // nolint
 			{
 				Type: "stub",
 				Name: "stub",

--- a/core/resource_groups.go
+++ b/core/resource_groups.go
@@ -15,7 +15,10 @@
 package core
 
 import (
+	"context"
+
 	"github.com/goccy/go-yaml"
+	"github.com/sacloud/libsacloud/v2/sacloud"
 )
 
 // ResourceGroups 一意な名前をキーとするリソースのリスト
@@ -62,4 +65,14 @@ func (rg *ResourceGroups) UnmarshalYAML(data []byte) error {
 	}
 	*rg = ResourceGroups{groups: loaded}
 	return nil
+}
+
+func (rg *ResourceGroups) Validate(ctx context.Context, apiClient sacloud.APICaller, handlers Handlers) []error {
+	var errors []error
+	for _, group := range rg.groups {
+		if errs := group.Validate(ctx, apiClient, handlers); len(errs) > 0 {
+			errors = append(errors, errs...)
+		}
+	}
+	return errors
 }

--- a/core/resource_server_group.go
+++ b/core/resource_server_group.go
@@ -14,14 +14,18 @@
 
 package core
 
-import "github.com/sacloud/libsacloud/v2/sacloud"
+import (
+	"context"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
 
 type ServerGroup struct {
 	*ResourceBase `yaml:",inline"`
 	wrapper       Resource
 }
 
-func (s *ServerGroup) Validate() error {
+func (s *ServerGroup) Validate(ctx context.Context, apiClient sacloud.APICaller) []error {
 	// TODO 実装
 	return nil
 }

--- a/core/resource_stub_test.go
+++ b/core/resource_stub_test.go
@@ -15,6 +15,8 @@
 package core
 
 import (
+	"context"
+
 	"github.com/sacloud/autoscaler/handler"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 )
@@ -24,7 +26,7 @@ type stubResource struct {
 	computeFunc   func(ctx *Context, apiClient sacloud.APICaller) (Computed, error)
 }
 
-func (r *stubResource) Validate() error {
+func (r *stubResource) Validate(ctx context.Context, apiClient sacloud.APICaller) []error {
 	return nil
 }
 

--- a/core/resources.go
+++ b/core/resources.go
@@ -14,8 +14,28 @@
 
 package core
 
+import (
+	"context"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
+
 // Resources リソースのリスト
 type Resources []Resource
+
+func (r *Resources) Validate(ctx context.Context, apiClient sacloud.APICaller) []error {
+	var errors []error
+
+	fn := func(r Resource) error {
+		if errs := r.Validate(ctx, apiClient); len(errs) > 0 {
+			errors = append(errors, errs...)
+		}
+		return nil
+	}
+
+	r.Walk(fn, nil) // nolint
+	return errors
+}
 
 type ResourceWalkFunc func(Resource) error
 

--- a/core/sakuracloud.go
+++ b/core/sakuracloud.go
@@ -14,7 +14,74 @@
 
 package core
 
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	"sync"
+
+	"github.com/sacloud/autoscaler/version"
+	"github.com/sacloud/libsacloud/v2"
+	"github.com/sacloud/libsacloud/v2/helper/api"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
 type SakuraCloud struct {
 	Credential `yaml:",inline"`
 	// TODO 項目追加
+
+	apiClient sacloud.APICaller
+	initOnce  sync.Once
+}
+
+// APIClient シングルトンなAPIクライアントを返す
+func (sc *SakuraCloud) APIClient() sacloud.APICaller {
+	sc.initOnce.Do(func() {
+		token := sc.Token
+		if token == "" {
+			token = os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
+		}
+		secret := sc.Secret
+		if secret == "" {
+			secret = os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
+		}
+
+		ua := fmt.Sprintf(
+			"sacloud/autoscaler/v%s (%s/%s; +https://github.com/sacloud/autoscaler) libsacloud/%s",
+			version.Version,
+			runtime.GOOS,
+			runtime.GOARCH,
+			libsacloud.Version,
+		)
+
+		httpClient := &http.Client{}
+		sc.apiClient = api.NewCaller(&api.CallerOptions{
+			AccessToken:       token,
+			AccessTokenSecret: secret,
+			HTTPClient:        httpClient,
+			UserAgent:         ua,
+			TraceAPI:          os.Getenv("SAKURACLOUD_TRACE") != "",
+			TraceHTTP:         os.Getenv("SAKURACLOUD_TRACE") != "",
+			FakeMode:          os.Getenv("FAKE_MODE") != "",
+		})
+	})
+	return sc.apiClient
+}
+
+// Validate 有効なAPIキーが指定されており、必要なパーミッションが割り当てられていることを確認する
+func (sc *SakuraCloud) Validate(ctx context.Context) error {
+	authStatus, err := sacloud.NewAuthStatusOp(sc.APIClient()).Read(ctx)
+	if err != nil {
+		if err, ok := err.(sacloud.APIError); ok {
+			return fmt.Errorf("reading SAKURA cloud account info failed: %s", err.Message())
+		}
+		return fmt.Errorf("reading SAKURA cloud account info failed: unknown error: %s", err)
+	}
+	if authStatus.Permission != types.Permissions.Create && authStatus.Permission != types.Permissions.Arrange {
+		return fmt.Errorf("required permissions have not been assigned. assigned permission: %s", authStatus.Permission)
+	}
+	return nil
 }

--- a/handlers/elb/servers_handler.go
+++ b/handlers/elb/servers_handler.go
@@ -58,7 +58,6 @@ func (h *ServersHandler) PreHandle(req *handler.PreHandleRequest, sender handler
 	}
 
 	if req.Instruction == handler.ResourceInstructions_UPDATE && h.shouldHandle(req.Desired) {
-		// TODO 入力値のバリデーション
 		server := req.Desired.GetServer()
 		elb := server.Parent.GetElb() // バリデーション済みなためnilチェック不要
 		if err := h.handle(ctx, req.ScalingJobId, server, elb, sender, false); err != nil {
@@ -84,7 +83,6 @@ func (h *ServersHandler) PostHandle(req *handler.PostHandleRequest, sender handl
 	}
 
 	if req.Result == handler.PostHandleRequest_UPDATED && h.shouldHandle(req.Desired) {
-		// TODO 入力値のバリデーション
 		server := req.Desired.GetServer()
 		elb := server.Parent.GetElb() // バリデーション済みなためnilチェック不要
 		if err := h.handle(ctx, req.ScalingJobId, server, elb, sender, true); err != nil {

--- a/handlers/elb/vertical_scale_handler.go
+++ b/handlers/elb/vertical_scale_handler.go
@@ -49,7 +49,6 @@ func (h *VerticalScaleHandler) Handle(req *handler.HandleRequest, sender handler
 
 	elb := req.Desired.GetElb()
 	if elb != nil && req.Instruction == handler.ResourceInstructions_UPDATE {
-		// TODO 入力値のバリデーション
 		if err := h.handleELB(ctx, req, elb, sender); err != nil {
 			return err
 		}

--- a/handlers/gslb/servers_handler.go
+++ b/handlers/gslb/servers_handler.go
@@ -58,7 +58,6 @@ func (h *ServersHandler) PreHandle(req *handler.PreHandleRequest, sender handler
 	}
 
 	if req.Instruction == handler.ResourceInstructions_UPDATE && h.shouldHandle(req.Desired) {
-		// TODO 入力値のバリデーション
 		server := req.Desired.GetServer()
 		gslb := server.Parent.GetGslb() // バリデーション済みなためnilチェック不要
 		if err := h.handle(ctx, req.ScalingJobId, server, gslb, sender, false); err != nil {
@@ -84,7 +83,6 @@ func (h *ServersHandler) PostHandle(req *handler.PostHandleRequest, sender handl
 	}
 
 	if req.Result == handler.PostHandleRequest_UPDATED && h.shouldHandle(req.Desired) {
-		// TODO 入力値のバリデーション
 		server := req.Desired.GetServer()
 		gslb := server.Parent.GetGslb() // バリデーション済みなためnilチェック不要
 		if err := h.handle(ctx, req.ScalingJobId, server, gslb, sender, true); err != nil {

--- a/handlers/router/vertical_scale_handler.go
+++ b/handlers/router/vertical_scale_handler.go
@@ -50,7 +50,6 @@ func (h *VerticalScaleHandler) Handle(req *handler.HandleRequest, sender handler
 
 	router := req.Desired.GetRouter()
 	if router != nil && req.Instruction == handler.ResourceInstructions_UPDATE {
-		// TODO 入力値のバリデーション
 		if err := h.handleRouter(ctx, req, router, sender); err != nil {
 			return err
 		}

--- a/handlers/server/vertical_scale_handler.go
+++ b/handlers/server/vertical_scale_handler.go
@@ -52,7 +52,6 @@ func (h *VerticalScaleHandler) Handle(req *handler.HandleRequest, sender handler
 
 	server := req.Desired.GetServer()
 	if server != nil && req.Instruction == handler.ResourceInstructions_UPDATE {
-		// TODO 入力値のバリデーション
 		if err := h.handleServer(ctx, req, server, sender); err != nil {
 			return err
 		}

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -32,7 +32,6 @@ func Struct(v interface{}) error {
 		}
 		return name
 	})
-	// TODO エラーメッセージのカスタマイズ
 	err := validate.Struct(v)
 	if err != nil {
 		if err != nil {

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	// Version app version
-	Version = "0.0.0"
+	Version = "0.0.0-dev"
 	// Revision git commit short commithash
 	Revision = "xxxxxx" // set on build time
 )


### PR DESCRIPTION
closes #42

- CLIフラグのバリデーションを追加
- Coreでの各種バリデーションの実装

バリデーション結果の例:

```console
$ autoscaler server start

Error: 3 errors occurred:
	* resource group=web: resource=Server: plan{zone:is1a, core:4, memory:1, dedicated_cpu:false} not exists
	* resource group=web: resource=Server: plan name "level3" is duplicated
	* resource group=web: resource=Server: plan{zone:is1a, core:5, memory:1, dedicated_cpu:false} not exists
```