### PR TITLE
Improved gRPC connection processing

### DIFF
--- a/commands/inputs/direct/cmd.go
+++ b/commands/inputs/direct/cmd.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/sacloud/autoscaler/defaults"
+	"github.com/sacloud/autoscaler/grpcutil"
 	"github.com/sacloud/autoscaler/request"
 	"github.com/sacloud/autoscaler/validate"
 	"github.com/spf13/cobra"
@@ -63,12 +64,11 @@ func init() {
 func run(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	// TODO 簡易的な実装、後ほど整理&切り出し
-	conn, err := grpc.DialContext(ctx, param.Destination, grpc.WithInsecure())
+	conn, cleanup, err := grpcutil.DialContext(ctx, &grpcutil.DialOption{Destination: param.Destination})
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer cleanup()
 
 	req := request.NewScalingServiceClient(conn)
 	var f func(ctx context.Context, in *request.ScalingRequest, opts ...grpc.CallOption) (*request.ScalingResponse, error)

--- a/core/handler.go
+++ b/core/handler.go
@@ -17,6 +17,7 @@ package core
 import (
 	"io"
 
+	"github.com/sacloud/autoscaler/grpcutil"
 	"github.com/sacloud/autoscaler/handler"
 	"github.com/sacloud/autoscaler/handlers"
 	"github.com/sacloud/autoscaler/handlers/builtins"
@@ -24,7 +25,6 @@ import (
 	"github.com/sacloud/autoscaler/handlers/gslb"
 	"github.com/sacloud/autoscaler/handlers/router"
 	"github.com/sacloud/autoscaler/handlers/server"
-	"google.golang.org/grpc"
 )
 
 type Handlers []*Handler
@@ -193,12 +193,11 @@ func (h *Handler) postHandleBuiltin(ctx *HandlingContext, computed Computed) err
 }
 
 func (h *Handler) preHandleExternal(ctx *HandlingContext, computed Computed) error {
-	// TODO 簡易的な実装、後ほど整理&切り出し
-	conn, err := grpc.DialContext(ctx, h.Endpoint, grpc.WithInsecure())
+	conn, cleanup, err := grpcutil.DialContext(ctx, &grpcutil.DialOption{Destination: h.Endpoint})
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer cleanup()
 
 	client := handler.NewHandleServiceClient(conn)
 	handleArg := &handleArg{
@@ -214,12 +213,11 @@ func (h *Handler) preHandleExternal(ctx *HandlingContext, computed Computed) err
 }
 
 func (h *Handler) handleExternal(ctx *HandlingContext, computed Computed) error {
-	// TODO 簡易的な実装、後ほど整理&切り出し
-	conn, err := grpc.DialContext(ctx, h.Endpoint, grpc.WithInsecure())
+	conn, cleanup, err := grpcutil.DialContext(ctx, &grpcutil.DialOption{Destination: h.Endpoint})
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer cleanup()
 
 	client := handler.NewHandleServiceClient(conn)
 	handleArg := &handleArg{
@@ -235,12 +233,11 @@ func (h *Handler) handleExternal(ctx *HandlingContext, computed Computed) error 
 }
 
 func (h *Handler) postHandleExternal(ctx *HandlingContext, computed Computed) error {
-	// TODO 簡易的な実装、後ほど整理&切り出し
-	conn, err := grpc.DialContext(ctx, h.Endpoint, grpc.WithInsecure())
+	conn, cleanup, err := grpcutil.DialContext(ctx, &grpcutil.DialOption{Destination: h.Endpoint})
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer cleanup()
 
 	client := handler.NewHandleServiceClient(conn)
 	handleArg := &handleArg{

--- a/grpcutil/dial.go
+++ b/grpcutil/dial.go
@@ -1,0 +1,39 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcutil
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+type DialOption struct {
+	Destination string
+	// TODO TLS対応する際にはここに項目を追加していく
+}
+
+// DialContext 指定のオプションでgRPCクライアント接続を行い、コネクションとクリーンアップ用funcを返す
+func DialContext(ctx context.Context, opt *DialOption) (*grpc.ClientConn, func(), error) {
+	transportOption := grpc.WithInsecure() // 現状ではunix or unix-abstract or http のみサポート
+
+	conn, err := grpc.DialContext(ctx, opt.Destination, transportOption)
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, func() {
+		conn.Close() // nolint
+	}, nil
+}

--- a/grpcutil/listener.go
+++ b/grpcutil/listener.go
@@ -1,0 +1,53 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcutil
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+)
+
+type ListenerOption struct {
+	Address string
+	// TODO TLS対応する際にはここに項目を追加していく
+}
+
+// Listener 指定のオプションでリッスン構成をした後でリッスンし、net.Listenerとクリーンアップ用のfuncを返す
+func Listener(opt *ListenerOption) (net.Listener, func(), error) {
+	target := ParseTarget(opt.Address, false)
+
+	schema := "tcp"
+	if target.Scheme == "unix" || target.Scheme == "unix-abstract" {
+		schema = "unix"
+	}
+
+	listener, err := net.Listen(schema, target.Endpoint)
+	if err != nil {
+		return nil, nil, fmt.Errorf("net.Listen failed: %s", err)
+	}
+
+	return listener, func() {
+		listener.Close() // nolint
+		if schema == "unix" {
+			if _, err := os.Stat(target.Endpoint); err == nil {
+				if err := os.RemoveAll(target.Endpoint); err != nil {
+					log.Printf("cleanup failed: %s", err) // nolint
+				}
+			}
+		}
+	}, nil
+}

--- a/grpcutil/target.go
+++ b/grpcutil/target.go
@@ -1,0 +1,92 @@
+// This file copied from github.com/grpc/grpc-go.
+// Original License is as follows:
+
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package grpcutil provides a bunch of utility functions to be used across the
+// gRPC codebase.
+package grpcutil
+
+import (
+	"strings"
+
+	"google.golang.org/grpc/resolver"
+)
+
+// split2 returns the values from strings.SplitN(s, sep, 2).
+// If sep is not found, it returns ("", "", false) instead.
+func split2(s, sep string) (string, string, bool) {
+	spl := strings.SplitN(s, sep, 2)
+	if len(spl) < 2 {
+		return "", "", false
+	}
+	return spl[0], spl[1], true
+}
+
+// ParseTarget splits target into a resolver.Target struct containing scheme,
+// authority and endpoint. skipUnixColonParsing indicates that the parse should
+// not parse "unix:[path]" cases. This should be true in cases where a custom
+// dialer is present, to prevent a behavior change.
+//
+// If target is not a valid scheme://authority/endpoint as specified in
+// https://github.com/grpc/grpc/blob/master/doc/naming.md,
+// it returns {Endpoint: target}.
+func ParseTarget(target string, skipUnixColonParsing bool) (ret resolver.Target) {
+	var ok bool
+	if strings.HasPrefix(target, "unix-abstract:") {
+		if strings.HasPrefix(target, "unix-abstract://") {
+			// Maybe, with Authority specified, try to parse it
+			var remain string
+			ret.Scheme, remain, _ = split2(target, "://")
+			ret.Authority, ret.Endpoint, ok = split2(remain, "/")
+			if !ok {
+				// No Authority, add the "//" back
+				ret.Endpoint = "//" + remain
+			} else {
+				// Found Authority, add the "/" back
+				ret.Endpoint = "/" + ret.Endpoint
+			}
+		} else {
+			// Without Authority specified, split target on ":"
+			ret.Scheme, ret.Endpoint, _ = split2(target, ":")
+		}
+		return ret
+	}
+	ret.Scheme, ret.Endpoint, ok = split2(target, "://")
+	if !ok {
+		if strings.HasPrefix(target, "unix:") && !skipUnixColonParsing {
+			// Handle the "unix:[local/path]" and "unix:[/absolute/path]" cases,
+			// because splitting on :// only handles the
+			// "unix://[/absolute/path]" case. Only handle if the dialer is nil,
+			// to avoid a behavior change with custom dialers.
+			return resolver.Target{Scheme: "unix", Endpoint: target[len("unix:"):]}
+		}
+		return resolver.Target{Endpoint: target}
+	}
+	ret.Authority, ret.Endpoint, ok = split2(ret.Endpoint, "/")
+	if !ok {
+		return resolver.Target{Endpoint: target}
+	}
+	if ret.Scheme == "unix" {
+		// Add the "/" back in the unix case, so the unix resolver receives the
+		// actual endpoint in the "unix://[/absolute/path]" case.
+		ret.Endpoint = "/" + ret.Endpoint
+	}
+	return ret
+}

--- a/inputs/inputs.go
+++ b/inputs/inputs.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/sacloud/autoscaler/defaults"
+	"github.com/sacloud/autoscaler/grpcutil"
 	"github.com/sacloud/autoscaler/log"
 	"github.com/sacloud/autoscaler/request"
 	"google.golang.org/grpc"
@@ -199,12 +200,11 @@ func (s *server) send(scalingReq *ScalingRequest) error {
 	}
 	ctx := context.Background()
 
-	// TODO 簡易的な実装、後ほど整理&切り出し
-	conn, err := grpc.DialContext(ctx, s.coreAddress, grpc.WithInsecure())
+	conn, cleanup, err := grpcutil.DialContext(ctx, &grpcutil.DialOption{Destination: s.coreAddress})
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
+	defer cleanup()
 
 	req := request.NewScalingServiceClient(conn)
 	var f func(ctx context.Context, in *request.ScalingRequest, opts ...grpc.CallOption) (*request.ScalingResponse, error)


### PR DESCRIPTION
closes #67 

- grpcutilパッケージの追加
- gRPCサーバ側のリッスンアドレスとしてhttps://github.com/grpc/grpc/blob/master/doc/naming.md に沿ったパラメータを受け付ける
  (ただしTLS関連は未実装)
- gRPCクライアント側の接続処理を切り出し