### PR TITLE
Remove 'Type' field from core.Handler

### DIFF
--- a/commands/server/example/example.yaml
+++ b/commands/server/example/example.yaml
@@ -83,8 +83,7 @@ resources:
 
 # カスタムハンドラーの定義
 # handlers:
-#   - type: "example"
-#     name: "example"
+#   - name: "example"
 #     endpoint: "unix:autoscaler-handlers-example.sock"
 
 # オートスケーラーの動作設定

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -49,7 +49,6 @@ func TestConfig_Load(t *testing.T) {
 				},
 				Handlers: Handlers{
 					{
-						Type:     "fake",
 						Name:     "fake",
 						Endpoint: "unix:autoscaler-handlers-fake.sock",
 					},
@@ -82,8 +81,7 @@ sakuracloud:
   token: token
   secret: secret
 handlers:
-  - type: "fake"
-    name: "fake"
+  - name: "fake"
     endpoint: "unix:autoscaler-handlers-fake.sock"
 resources:
   web: 

--- a/core/handler.go
+++ b/core/handler.go
@@ -37,35 +37,30 @@ type Handlers []*Handler
 func BuiltinHandlers() Handlers {
 	return Handlers{
 		{
-			Type: "elb-vertical-scaler",
 			Name: "elb-vertical-scaler",
 			BuiltinHandler: &builtins.Handler{
 				Builtin: elb.NewVerticalScaleHandler(),
 			},
 		},
 		{
-			Type: "elb-servers-handler",
 			Name: "elb-servers-handler",
 			BuiltinHandler: &builtins.Handler{
 				Builtin: elb.NewServersHandler(),
 			},
 		},
 		{
-			Type: "gslb-servers-handler",
 			Name: "gslb-servers-handler",
 			BuiltinHandler: &builtins.Handler{
 				Builtin: gslb.NewServersHandler(),
 			},
 		},
 		{
-			Type: "router-vertical-scaler",
 			Name: "router-vertical-scaler",
 			BuiltinHandler: &builtins.Handler{
 				Builtin: router.NewVerticalScaleHandler(),
 			},
 		},
 		{
-			Type: "server-vertical-scaler",
 			Name: "server-vertical-scaler",
 			BuiltinHandler: &builtins.Handler{
 				Builtin: server.NewVerticalScaleHandler(),
@@ -76,8 +71,7 @@ func BuiltinHandlers() Handlers {
 
 // Handler カスタムハンドラーの定義
 type Handler struct {
-	Type           string               `yaml:"type"`     // ハンドラー種別
-	Name           string               `yaml:"name"`     // ハンドラーを識別するための名称 同一Typeで複数のハンドラーが存在する場合が存在するため、Nameで一意に識別する
+	Name           string               `yaml:"name"`     // ハンドラーを識別するための名称
 	Endpoint       string               `yaml:"endpoint"` // カスタムハンドラーの場合にのみ指定
 	BuiltinHandler handlers.HandlerMeta `yaml:"-"`        // ビルトインハンドラーの場合のみ指定
 	Disabled       bool                 `yaml:"-"`        // ビルトインハンドラーの場合のみ指定

--- a/core/resource_group_test.go
+++ b/core/resource_group_test.go
@@ -31,15 +31,12 @@ import (
 func TestResourceGroup_handlers(t *testing.T) {
 	allHandlers := Handlers{
 		{
-			Type: "dummy",
 			Name: "dummy1",
 		},
 		{
-			Type: "dummy",
 			Name: "dummy2",
 		},
 		{
-			Type:     "dummy",
 			Name:     "dummy3",
 			Disabled: true,
 		},
@@ -73,11 +70,9 @@ func TestResourceGroup_handlers(t *testing.T) {
 			},
 			want: Handlers{
 				{
-					Type: "dummy",
 					Name: "dummy1",
 				},
 				{
-					Type: "dummy",
 					Name: "dummy2",
 				},
 			},
@@ -128,7 +123,6 @@ func TestResourceGroup_handlers(t *testing.T) {
 			},
 			want: Handlers{
 				{
-					Type:     "dummy",
 					Name:     "dummy3",
 					Disabled: true,
 				},
@@ -149,7 +143,6 @@ func TestResourceGroup_handlers(t *testing.T) {
 			},
 			want: Handlers{
 				{
-					Type: "dummy",
 					Name: "dummy2",
 				},
 			},
@@ -169,7 +162,6 @@ func TestResourceGroup_handlers(t *testing.T) {
 			},
 			want: Handlers{
 				{
-					Type: "dummy",
 					Name: "dummy2",
 				},
 			},
@@ -217,7 +209,6 @@ func TestResourceGroup_handleAll(t *testing.T) {
 
 		rg.handleAll(testContext(), test.APIClient, Handlers{ // nolint
 			{
-				Type: "stub",
 				Name: "stub",
 				BuiltinHandler: &builtins.Handler{
 					Builtin: &stub.Handler{
@@ -288,7 +279,6 @@ func TestResourceGroup_handleAll(t *testing.T) {
 
 		rg.handleAll(testContext(), test.APIClient, Handlers{ // nolint
 			{
-				Type: "stub",
 				Name: "stub",
 				BuiltinHandler: &stub.Handler{
 					PreHandleFunc: func(request *handler.PreHandleRequest, sender handlers.ResponseSender) error {


### PR DESCRIPTION
core.Handlerから`Type`フィールドを除去する。

本来はTypeとNameの組み合わせでハンドラを一意に識別する方針だったが、
TypeとNameが異なるケースが今のところシェルスクリプトハンドラーのみ、
かつシェルスクリプトハンドラーはビルトインにしないつもりなのでTypeフィールドは利用しなくなった。
