### PR TITLE
Added -v/--version flag to rootCmd

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -21,7 +21,8 @@ import (
 	"github.com/sacloud/autoscaler/commands/flags"
 	"github.com/sacloud/autoscaler/commands/inputs"
 	"github.com/sacloud/autoscaler/commands/server"
-	"github.com/sacloud/autoscaler/commands/version"
+	cmdVersion "github.com/sacloud/autoscaler/commands/version"
+	"github.com/sacloud/autoscaler/version"
 	"github.com/spf13/cobra"
 )
 
@@ -31,17 +32,19 @@ var rootCmd = &cobra.Command{
 	PersistentPreRunE: flags.ValidateLogFlags,
 	SilenceUsage:      true,
 	SilenceErrors:     false,
+	Version:           version.Version,
 }
 
 var subCommands = []*cobra.Command{
 	completion.Command,
 	inputs.Command,
 	server.Command,
-	version.Command,
+	cmdVersion.Command,
 }
 
 func init() {
 	flags.SetLogFlags(rootCmd)
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
 	rootCmd.AddCommand(subCommands...)
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	// Version app version
-	Version = "0.0.0-dev"
+	Version = "v0.0.0-dev"
 	// Revision git commit short commithash
 	Revision = "xxxxxx" // set on build time
 )


### PR DESCRIPTION
-v または --versionでバージョン情報を表示する。

`autoscaler version`サブコマンドとの違いは詳細表示の有無。
`autoscaler version -a`でリビジョンを含めた詳細情報を表示する。