### PR TITLE
Build and publish e2e image for Internal CI

### DIFF
--- a/.github/workflows/publish_e2e_docker_image.yaml
+++ b/.github/workflows/publish_e2e_docker_image.yaml
@@ -1,0 +1,31 @@
+# from https://docs.github.com/en/free-pro-team@latest/actions/guides/publishing-docker-images#publishing-images-to-github-packages
+name: Publish Docker image(e2e)
+on:
+  push:
+    branches:
+      - main
+jobs:
+  push_to_registry:
+    name: Push Docker image to GitHub Container Registry(e2e)
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Check out the repo
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      -
+        name: Build and push to GitHub Container Registry
+        uses: docker/build-push-action@v2
+        with:
+          tags: ghcr.io/sacloud/autoscaler:e2e
+          file: e2e/Dockerfile
+          push: true


### PR DESCRIPTION
TeamCityによるCI(プライベート環境、DinDに非対応)でも利用できるようにe2e用のイメージをGitHub Container Registryで公開する。

第1弾としてこのPRでイメージのビルド/公開を行い、後続PRでe2e時にこのイメージを利用するように修正する。