### PR TITLE
Set exit status

### DIFF
--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -38,3 +38,4 @@ usacloud proxy-lb delete -y `usacloud proxy-lb read -q autoscaler-e2e-test` > /d
 fi
 
 echo "Done: $RESULT"
+exit $RESULT


### PR DESCRIPTION
e2eテスト用のスクリプトの最後でechoしているだけなため終了コードが0になる。
このため`exit`で明示する。