### PR TITLE
Set default retry/timeout setting for API client

### DIFF
--- a/core/sakuracloud.go
+++ b/core/sakuracloud.go
@@ -59,13 +59,16 @@ func (sc *SakuraCloud) APIClient() sacloud.APICaller {
 
 		httpClient := &http.Client{}
 		sc.apiClient = api.NewCaller(&api.CallerOptions{
-			AccessToken:       token,
-			AccessTokenSecret: secret,
-			HTTPClient:        httpClient,
-			UserAgent:         ua,
-			TraceAPI:          os.Getenv("SAKURACLOUD_TRACE") != "",
-			TraceHTTP:         os.Getenv("SAKURACLOUD_TRACE") != "",
-			FakeMode:          os.Getenv("FAKE_MODE") != "",
+			AccessToken:          token,
+			AccessTokenSecret:    secret,
+			HTTPClient:           httpClient,
+			HTTPRequestTimeout:   300,
+			HTTPRequestRateLimit: 10,
+			RetryMax:             10,
+			UserAgent:            ua,
+			TraceAPI:             os.Getenv("SAKURACLOUD_TRACE") != "",
+			TraceHTTP:            os.Getenv("SAKURACLOUD_TRACE") != "",
+			FakeMode:             os.Getenv("FAKE_MODE") != "",
 		})
 	})
 	return sc.apiClient

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -70,8 +70,11 @@ var apiCaller = api.NewCaller(&api.CallerOptions{
 		runtime.GOARCH,
 		libsacloud.Version,
 	),
-	TraceAPI:  os.Getenv("SAKURACLOUD_TRACE") != "",
-	TraceHTTP: os.Getenv("SAKURACLOUD_TRACE") != "",
+	HTTPRequestTimeout:   300,
+	HTTPRequestRateLimit: 10,
+	RetryMax:             10,
+	TraceAPI:             os.Getenv("SAKURACLOUD_TRACE") != "",
+	TraceHTTP:            os.Getenv("SAKURACLOUD_TRACE") != "",
 })
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
closes #116 

APIクライアントのリトライ/タイムアウトの設定を行う。
このPR時点では固定値を設定しておく。今後オプションなどで指定可能にする。

デフォルト値は実績のあるterraform-provider-sakuracloudの値を流用する。

