### PR TITLE
Added basic interface/struct for Definitions

### DIFF
--- a/core/resource2.go
+++ b/core/resource2.go
@@ -1,0 +1,37 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import "github.com/sacloud/libsacloud/v2/sacloud"
+
+// Resource2 Definitionから作られるResource
+//
+// TODO 現行Resourceとの切り替え時に名前変更する
+type Resource2 interface {
+	// Type リソースの型
+	Type() ResourceTypes
+
+	// Compute リクエストに沿った、希望する状態を算出する
+	//
+	// refreshがtrueの場合、さくらのクラウドAPIを用いて最新の状態に更新した上で処理を行う
+	Compute(ctx *RequestContext, apiClient sacloud.APICaller, refresh bool) (Computed, error)
+
+	// Children 子リソース
+	Children() Resources2
+	// SetChildren 子リソースを設定
+	SetChildren(Resources2)
+}
+
+type Resources2 []Resource2

--- a/core/resource2_stub_test.go
+++ b/core/resource2_stub_test.go
@@ -1,0 +1,63 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
+
+type stubResourceDef struct {
+	*ResourceDefBase
+	computeFunc func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error)
+}
+
+func (d *stubResourceDef) Validate(ctx context.Context, apiClient sacloud.APICaller) []error {
+	return nil
+}
+
+func (d *stubResourceDef) Compute(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
+	if d.computeFunc != nil {
+		return d.computeFunc(ctx, apiClient)
+	}
+	return nil, nil
+}
+
+// TODO リソース切り替え時に名前変更
+type stubResource2 struct {
+	resourceType ResourceTypes
+	computeFunc  func(ctx *RequestContext, apiClient sacloud.APICaller, refresh bool) (Computed, error)
+	children     Resources2
+}
+
+func (r *stubResource2) Type() ResourceTypes {
+	return r.resourceType
+}
+
+func (r *stubResource2) Compute(ctx *RequestContext, apiClient sacloud.APICaller, refresh bool) (Computed, error) {
+	if r.computeFunc != nil {
+		return r.computeFunc(ctx, apiClient, refresh)
+	}
+	return nil, nil
+}
+
+func (r *stubResource2) Children() Resources2 {
+	return r.children
+}
+
+func (r *stubResource2) SetChildren(children Resources2) {
+	r.children = children
+}

--- a/core/resource_def_group.go
+++ b/core/resource_def_group.go
@@ -1,0 +1,138 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/sacloud/autoscaler/defaults"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
+
+// ResourceDefGroup アクションとリソース定義の組み合わせ
+type ResourceDefGroup struct {
+	Actions      Actions             `yaml:"actions"`
+	ResourceDefs ResourceDefinitions `yaml:"resources"`
+
+	name string // ResourceGroupsのアンマーシャル時に設定される
+}
+
+// TODO UnmarshalYAMLを実装する
+
+func (rg *ResourceDefGroup) ValidateActions(actionName string, handlerFilters Handlers) error {
+	_, err := rg.handlers(actionName, handlerFilters)
+	return err
+}
+
+func (rg *ResourceDefGroup) Validate(ctx context.Context, apiClient sacloud.APICaller, handlers Handlers) []error {
+	errors := &multierror.Error{}
+
+	// Actions
+	errors = multierror.Append(errors, rg.Actions.Validate(ctx, handlers)...)
+	// Resources
+	errors = multierror.Append(errors, rg.ResourceDefs.Validate(ctx, apiClient)...)
+
+	// set group name prefix
+	errors = multierror.Prefix(errors, fmt.Sprintf("resource def group=%s:", rg.name)).(*multierror.Error)
+
+	return errors.Errors
+}
+
+func (rg *ResourceDefGroup) ResourceGroup(ctx *RequestContext, apiClient sacloud.APICaller) (*ResourceGroup2, error) {
+	group := &ResourceGroup2{
+		Resources: Resources2{},
+	}
+
+	if err := rg.buildResourceGroup(ctx, apiClient, group, nil, rg.ResourceDefs); err != nil {
+		return nil, err
+	}
+	return group, nil
+}
+
+func (rg *ResourceDefGroup) buildResourceGroup(ctx *RequestContext, apiClient sacloud.APICaller, group *ResourceGroup2, parent Resource2, defs ResourceDefinitions) error {
+	for _, def := range defs {
+		resources, err := def.Compute(ctx, apiClient)
+		if err != nil {
+			return err
+		}
+		if len(resources) == 0 {
+			return fmt.Errorf("ResourceDefinition did not return any resources")
+		}
+		if def.Children() != nil && len(resources) > 1 {
+			// 親リソースになっている場合は複数リソースを許容しない
+			return fmt.Errorf("ResourceDefinition with children must return one resource, but got multiple resources")
+		}
+
+		// 親リソースが指定されてたらそちらに、以外はgroupに直接追加
+		if parent != nil {
+			parent.SetChildren(append(parent.Children(), resources...))
+		} else {
+			group.Resources = append(group.Resources, resources...)
+		}
+
+		if err := rg.buildResourceGroup(ctx, apiClient, group, resources[0], def.Children()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Handlers 引数で指定されたハンドラーのリストをActionsの定義に合致するハンドラだけにフィルタして返す
+func (rg *ResourceDefGroup) handlers(actionName string, allHandlers Handlers) (Handlers, error) {
+	var results Handlers
+
+	if len(rg.Actions) == 0 {
+		for _, h := range allHandlers {
+			if !h.Disabled {
+				results = append(results, h)
+			}
+		}
+		return results, nil
+	}
+
+	if actionName == "" || actionName == defaults.ActionName {
+		// Actionsが定義されている時にActionNameが省略 or デフォルトの場合はActionsの最初のキーを利用
+		// YAMLでの定義順とは限らないため注意
+		for k := range rg.Actions {
+			actionName = k
+			break
+		}
+	}
+
+	handlers, ok := rg.Actions[actionName]
+	if !ok {
+		return nil, fmt.Errorf("action %q not found", actionName)
+	}
+	if len(handlers) == 0 {
+		return nil, fmt.Errorf("action %q is empty", actionName)
+	}
+
+	for _, name := range handlers {
+		var found *Handler
+		for _, h := range allHandlers {
+			if h.Name == name {
+				found = h
+				break
+			}
+		}
+		if found == nil {
+			return nil, fmt.Errorf("handler %q not found", name)
+		}
+		results = append(results, found)
+	}
+	return results, nil
+}

--- a/core/resource_def_group_test.go
+++ b/core/resource_def_group_test.go
@@ -1,0 +1,384 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/sacloud/autoscaler/defaults"
+	"github.com/sacloud/autoscaler/test"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceDefGroup_handlers(t *testing.T) {
+	allHandlers := Handlers{
+		{
+			Name: "dummy1",
+		},
+		{
+			Name: "dummy2",
+		},
+		{
+			Name:     "dummy3",
+			Disabled: true,
+		},
+	}
+
+	type fields struct {
+		Actions Actions
+		Name    string
+	}
+	type args struct {
+		actionName  string
+		allHandlers Handlers
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    Handlers
+		wantErr bool
+	}{
+		{
+			name: "returns all enabled handlers if Actions is empty",
+			fields: fields{
+				Name:    "empty",
+				Actions: Actions{},
+			},
+			args: args{
+				actionName:  defaults.ActionName,
+				allHandlers: allHandlers,
+			},
+			want: Handlers{
+				{
+					Name: "dummy1",
+				},
+				{
+					Name: "dummy2",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "returns error if invalid ActionName is specified",
+			fields: fields{
+				Actions: Actions{
+					"foobar":   []string{"dummy1", "dummy2"},
+					"disabled": []string{"dummy1", "dummy2", "dummy3"},
+				},
+				Name: "not-exists",
+			},
+			args: args{
+				allHandlers: allHandlers,
+				actionName:  "not-exists",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "returns error with invalid definition of Actions",
+			fields: fields{
+				Actions: Actions{
+					"foobar": []string{},
+				},
+				Name: "foobar",
+			},
+			args: args{
+				allHandlers: allHandlers,
+				actionName:  "foobar",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "returns handlers even at Disabled:true",
+			fields: fields{
+				Actions: Actions{
+					"filter": []string{"dummy3"},
+				},
+				Name: "filter",
+			},
+			args: args{
+				allHandlers: allHandlers,
+				actionName:  "filter",
+			},
+			want: Handlers{
+				{
+					Name:     "dummy3",
+					Disabled: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "returns first handlers if action name is empty",
+			fields: fields{
+				Actions: Actions{
+					"action1": []string{"dummy2"},
+				},
+				Name: "filter",
+			},
+			args: args{
+				allHandlers: allHandlers,
+				actionName:  "",
+			},
+			want: Handlers{
+				{
+					Name: "dummy2",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "returns first handlers if action name is default value",
+			fields: fields{
+				Actions: Actions{
+					"action1": []string{"dummy2"},
+				},
+				Name: "filter",
+			},
+			args: args{
+				allHandlers: allHandlers,
+				actionName:  defaults.ActionName,
+			},
+			want: Handlers{
+				{
+					Name: "dummy2",
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rg := &ResourceDefGroup{
+				Actions: tt.fields.Actions,
+				name:    tt.fields.Name,
+			}
+			got, err := rg.handlers(tt.args.actionName, tt.args.allHandlers)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handlers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("handlers() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResourceDefGroup_ResourceGroup(t *testing.T) {
+	type fields struct {
+		ResourceDefs ResourceDefinitions
+	}
+	type args struct {
+		ctx       *RequestContext
+		apiClient sacloud.APICaller
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *ResourceGroup2
+		wantErr bool
+	}{
+		{
+			name: "basic",
+			fields: fields{
+				// DNS
+				//  |-- ELB1
+				//  |    |-- Server1
+				//  |    |-- Server2
+				//  |-- ELB2
+				//       |-- Server3
+				//       |-- Server4
+				// GSLB
+				//  |------- Server5
+				//  |------- Server6
+				ResourceDefs: ResourceDefinitions{
+					&stubResourceDef{
+						computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
+							return Resources2{
+								&stubResource2{resourceType: ResourceTypeDNS},
+							}, nil
+						},
+						ResourceDefBase: &ResourceDefBase{
+							TypeName: ResourceTypeDNS.String(),
+							children: ResourceDefinitions{
+								&stubResourceDef{
+									computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
+										return Resources2{
+											&stubResource2{resourceType: ResourceTypeEnhancedLoadBalancer},
+										}, nil
+									},
+									ResourceDefBase: &ResourceDefBase{
+										TypeName: ResourceTypeEnhancedLoadBalancer.String(),
+										children: ResourceDefinitions{
+											&stubResourceDef{
+												computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
+													return Resources2{
+														&stubResource2{resourceType: ResourceTypeServer},
+													}, nil
+												},
+												ResourceDefBase: &ResourceDefBase{
+													TypeName: ResourceTypeServer.String(),
+												},
+											},
+											&stubResourceDef{
+												computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
+													return Resources2{
+														&stubResource2{resourceType: ResourceTypeServer},
+													}, nil
+												},
+												ResourceDefBase: &ResourceDefBase{
+													TypeName: ResourceTypeServer.String(),
+												},
+											},
+										},
+									},
+								},
+								&stubResourceDef{
+									computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
+										return Resources2{
+											&stubResource2{resourceType: ResourceTypeEnhancedLoadBalancer},
+										}, nil
+									},
+									ResourceDefBase: &ResourceDefBase{
+										TypeName: ResourceTypeEnhancedLoadBalancer.String(),
+										children: ResourceDefinitions{
+											&stubResourceDef{
+												computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
+													return Resources2{
+														&stubResource2{resourceType: ResourceTypeServer},
+													}, nil
+												},
+												ResourceDefBase: &ResourceDefBase{
+													TypeName: ResourceTypeServer.String(),
+												},
+											},
+											&stubResourceDef{
+												computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
+													return Resources2{
+														&stubResource2{resourceType: ResourceTypeServer},
+													}, nil
+												},
+												ResourceDefBase: &ResourceDefBase{
+													TypeName: ResourceTypeServer.String(),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					&stubResourceDef{
+						ResourceDefBase: &ResourceDefBase{
+							TypeName: ResourceTypeGSLB.String(),
+							children: ResourceDefinitions{
+								&stubResourceDef{
+									computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
+										return Resources2{
+											&stubResource2{resourceType: ResourceTypeServer},
+										}, nil
+									},
+									ResourceDefBase: &ResourceDefBase{
+										TypeName: ResourceTypeServer.String(),
+									},
+								},
+								&stubResourceDef{
+									computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
+										return Resources2{
+											&stubResource2{resourceType: ResourceTypeServer},
+										}, nil
+									},
+									ResourceDefBase: &ResourceDefBase{
+										TypeName: ResourceTypeServer.String(),
+									},
+								},
+							},
+						},
+						computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
+							return Resources2{
+								&stubResource2{resourceType: ResourceTypeGSLB},
+							}, nil
+						},
+					},
+				},
+			},
+			args: args{
+				ctx: &RequestContext{
+					ctx: context.Background(),
+					request: &requestInfo{
+						requestType:       requestTypeUp,
+						source:            "default",
+						action:            "default",
+						resourceGroupName: "default",
+					},
+					job: &JobStatus{
+						requestType: requestTypeUp,
+						id:          "default-default-default",
+					},
+					logger: test.Logger,
+				},
+				apiClient: test.APIClient,
+			},
+			want: &ResourceGroup2{
+				Resources: Resources2{
+					&stubResource2{
+						resourceType: ResourceTypeDNS,
+						children: Resources2{
+							&stubResource2{
+								resourceType: ResourceTypeEnhancedLoadBalancer,
+								children: Resources2{
+									&stubResource2{resourceType: ResourceTypeServer},
+									&stubResource2{resourceType: ResourceTypeServer},
+								},
+							},
+							&stubResource2{
+								resourceType: ResourceTypeEnhancedLoadBalancer,
+								children: Resources2{
+									&stubResource2{resourceType: ResourceTypeServer},
+									&stubResource2{resourceType: ResourceTypeServer},
+								},
+							},
+						},
+					},
+					&stubResource2{
+						resourceType: ResourceTypeGSLB,
+						children: Resources2{
+							&stubResource2{resourceType: ResourceTypeServer},
+							&stubResource2{resourceType: ResourceTypeServer},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rg := &ResourceDefGroup{
+				ResourceDefs: tt.fields.ResourceDefs,
+			}
+			got, err := rg.ResourceGroup(tt.args.ctx, tt.args.apiClient)
+			require.Equal(t, tt.wantErr, err != nil)
+			require.EqualValues(t, tt.want, got)
+		})
+	}
+}

--- a/core/resource_definition.go
+++ b/core/resource_definition.go
@@ -1,0 +1,77 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
+
+// ResourceDefinition Coreが扱うさくらのクラウド上のリソースを表す
+//
+// Core起動時のコンフィギュレーションから形成される
+type ResourceDefinition interface {
+	Type() ResourceTypes // リソースの型
+	Selector() *ResourceSelector
+	Validate(ctx context.Context, apiClient sacloud.APICaller) []error
+
+	// Compute 現在/あるべき姿を算出する
+	//
+	// TypeとSelectorを元にさくらのクラウドAPIを用いて実リソースを検索、Resourceを作成して返す
+	Compute(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error)
+
+	// Children このリソースに対する子リソースを返す
+	Children() ResourceDefinitions
+}
+
+type ChildResourceDefinition interface {
+	Parent() ResourceDefinition
+	SetParent(parent ResourceDefinition)
+}
+
+// ResourceDefBase 全てのリソース定義が実装すべき基本プロパティ
+//
+// Resourceの実装に埋め込む場合、Compute()でComputedCacheを設定すること
+type ResourceDefBase struct {
+	TypeName       string              `yaml:"type"`
+	TargetSelector *ResourceSelector   `yaml:"selector"`
+	children       ResourceDefinitions `yaml:"-"`
+}
+
+func (r *ResourceDefBase) Type() ResourceTypes {
+	switch r.TypeName {
+	case ResourceTypeServer.String():
+		return ResourceTypeServer
+	case ResourceTypeServerGroup.String():
+		return ResourceTypeServerGroup
+	case ResourceTypeEnhancedLoadBalancer.String(), "ELB":
+		return ResourceTypeEnhancedLoadBalancer
+	case ResourceTypeGSLB.String():
+		return ResourceTypeGSLB
+	case ResourceTypeDNS.String():
+		return ResourceTypeDNS
+	}
+	return ResourceTypeUnknown
+}
+
+func (r *ResourceDefBase) Selector() *ResourceSelector {
+	return r.TargetSelector
+}
+
+// Children 子リソースを返す(自身は含まない)
+func (r *ResourceDefBase) Children() ResourceDefinitions {
+	return r.children
+}

--- a/core/resource_definitions.go
+++ b/core/resource_definitions.go
@@ -1,0 +1,89 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
+
+// ResourceDefinitions リソースのリスト
+type ResourceDefinitions []ResourceDefinition
+
+func (r *ResourceDefinitions) Validate(ctx context.Context, apiClient sacloud.APICaller) []error {
+	var errors []error
+
+	fn := func(r ResourceDefinition) error {
+		if errs := r.Validate(ctx, apiClient); len(errs) > 0 {
+			errors = append(errors, errs...)
+		}
+		return nil
+	}
+
+	if err := r.Walk(fn); err != nil {
+		errors = append(errors, err)
+	}
+	return errors
+}
+
+type ResourceDefWalkFunc func(definitions ResourceDefinition) error
+
+// Walk 各リソースに対し順次fnを適用する
+//
+// forwardFnの適用は上から行われる
+//
+// example:
+// resource1
+//  |
+//  |- resource2
+//      |
+//      |- resource3
+//      |- resource4
+//
+//  この場合は以下の処理順になる
+//    - forwardFn(resource1)
+//    - forwardFn(resource2)
+//    - forwardFn(resource3)
+//    - forwardFn(resource4)
+//
+// fnがerrorを返した場合は即時リターンし以降のリソースに対する処理は行われない
+func (r *ResourceDefinitions) Walk(fn ResourceDefWalkFunc) error {
+	return r.walk(*r, fn)
+}
+
+func (r *ResourceDefinitions) walk(targets ResourceDefinitions, fn ResourceDefWalkFunc) error {
+	noopFunc := func(_ ResourceDefinition) error {
+		return nil
+	}
+	if fn == nil {
+		fn = noopFunc
+	}
+
+	for _, target := range targets {
+		if err := fn(target); err != nil {
+			return err
+		}
+		for _, child := range target.Children() {
+			if err := fn(child); err != nil {
+				return err
+			}
+			if err := r.walk(child.Children(), fn); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/core/resource_group2.go
+++ b/core/resource_group2.go
@@ -1,0 +1,19 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+type ResourceGroup2 struct {
+	Resources Resources2 `yaml:"resources"`
+}


### PR DESCRIPTION
from #127 

Definitions関連のインターフェースと一部実装を追加する。  

<img width="1501" alt="image" src="https://user-images.githubusercontent.com/1644816/122348958-ac680e80-cf86-11eb-9801-c0af3a6d1863.png">

- 既存のResourceGroup/Resources/Resourceから定義関連を切り出し
- ResourceDefGroup.ResourceGroup()で定義からResourceGroupを算出
  - ResourceDefinition.Compute()でResourcesを算出
  - ResourceGroupに算出したResourcesを追加

:warning: 既存の実装を維持するために既存の実装と重複するinterface/structには一時的に別名をつけている。

- ResourceGroup2
- Resource2
- Resources2

これらは今後の#127対応の中でリネームする。

Note: 子を持つResourceDefinitionが複数のResourceを返すことがあり得るが、複数の親を許容すると実装が複雑になるため、この
PRではエラーとしておく。