### PR TITLE
Reference to the parent resource -> Computed

### DIFF
--- a/core/resource2.go
+++ b/core/resource2.go
@@ -30,8 +30,45 @@ type Resource2 interface {
 
 	// Children 子リソース
 	Children() Resources2
-	// SetChildren 子リソースを設定
-	SetChildren(Resources2)
+	// AppendChildren 子リソースを設定
+	AppendChildren(Resources2)
+
+	Parent() Resource2
 }
 
 type Resources2 []Resource2
+
+type ResourceBase2 struct {
+	resourceType ResourceTypes
+	parent       Resource2
+	children     Resources2
+}
+
+func NewResourceBase2(tp ResourceTypes, parent Resource2, children ...Resource2) *ResourceBase2 {
+	v := &ResourceBase2{
+		resourceType: tp,
+		parent:       parent,
+	}
+	for _, child := range children {
+		if child != nil {
+			v.children = append(v.children, child)
+		}
+	}
+	return v
+}
+
+func (r *ResourceBase2) Type() ResourceTypes {
+	return r.resourceType
+}
+
+func (r *ResourceBase2) Children() Resources2 {
+	return r.children
+}
+
+func (r *ResourceBase2) AppendChildren(children Resources2) {
+	r.children = append(r.children, children...)
+}
+
+func (r *ResourceBase2) Parent() Resource2 {
+	return r.parent
+}

--- a/core/resource2_stub_test.go
+++ b/core/resource2_stub_test.go
@@ -38,13 +38,8 @@ func (d *stubResourceDef) Compute(ctx *RequestContext, apiClient sacloud.APICall
 
 // TODO リソース切り替え時に名前変更
 type stubResource2 struct {
-	resourceType ResourceTypes
-	computeFunc  func(ctx *RequestContext, apiClient sacloud.APICaller, refresh bool) (Computed, error)
-	children     Resources2
-}
-
-func (r *stubResource2) Type() ResourceTypes {
-	return r.resourceType
+	*ResourceBase2
+	computeFunc func(ctx *RequestContext, apiClient sacloud.APICaller, refresh bool) (Computed, error)
 }
 
 func (r *stubResource2) Compute(ctx *RequestContext, apiClient sacloud.APICaller, refresh bool) (Computed, error) {
@@ -52,12 +47,4 @@ func (r *stubResource2) Compute(ctx *RequestContext, apiClient sacloud.APICaller
 		return r.computeFunc(ctx, apiClient, refresh)
 	}
 	return nil, nil
-}
-
-func (r *stubResource2) Children() Resources2 {
-	return r.children
-}
-
-func (r *stubResource2) SetChildren(children Resources2) {
-	r.children = children
 }

--- a/core/resource_def_group.go
+++ b/core/resource_def_group.go
@@ -78,10 +78,12 @@ func (rg *ResourceDefGroup) buildResourceGroup(ctx *RequestContext, apiClient sa
 		}
 
 		// 親リソースが指定されてたらそちらに、以外はgroupに直接追加
-		if parent != nil {
-			parent.SetChildren(append(parent.Children(), resources...))
-		} else {
-			group.Resources = append(group.Resources, resources...)
+		if len(resources) > 0 {
+			if parent != nil {
+				parent.AppendChildren(resources)
+			} else {
+				group.Resources = append(group.Resources, resources...)
+			}
 		}
 
 		if err := rg.buildResourceGroup(ctx, apiClient, group, resources[0], def.Children()); err != nil {

--- a/core/resource_def_group_test.go
+++ b/core/resource_def_group_test.go
@@ -214,7 +214,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 					&stubResourceDef{
 						computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 							return Resources2{
-								&stubResource2{resourceType: ResourceTypeDNS},
+								&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeDNS, nil)},
 							}, nil
 						},
 						ResourceDefBase: &ResourceDefBase{
@@ -223,7 +223,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 								&stubResourceDef{
 									computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 										return Resources2{
-											&stubResource2{resourceType: ResourceTypeEnhancedLoadBalancer},
+											&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeEnhancedLoadBalancer, nil)},
 										}, nil
 									},
 									ResourceDefBase: &ResourceDefBase{
@@ -232,7 +232,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 											&stubResourceDef{
 												computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 													return Resources2{
-														&stubResource2{resourceType: ResourceTypeServer},
+														&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
 													}, nil
 												},
 												ResourceDefBase: &ResourceDefBase{
@@ -242,7 +242,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 											&stubResourceDef{
 												computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 													return Resources2{
-														&stubResource2{resourceType: ResourceTypeServer},
+														&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
 													}, nil
 												},
 												ResourceDefBase: &ResourceDefBase{
@@ -255,7 +255,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 								&stubResourceDef{
 									computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 										return Resources2{
-											&stubResource2{resourceType: ResourceTypeEnhancedLoadBalancer},
+											&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeEnhancedLoadBalancer, nil)},
 										}, nil
 									},
 									ResourceDefBase: &ResourceDefBase{
@@ -264,7 +264,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 											&stubResourceDef{
 												computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 													return Resources2{
-														&stubResource2{resourceType: ResourceTypeServer},
+														&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
 													}, nil
 												},
 												ResourceDefBase: &ResourceDefBase{
@@ -274,7 +274,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 											&stubResourceDef{
 												computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 													return Resources2{
-														&stubResource2{resourceType: ResourceTypeServer},
+														&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
 													}, nil
 												},
 												ResourceDefBase: &ResourceDefBase{
@@ -288,13 +288,18 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 						},
 					},
 					&stubResourceDef{
+						computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
+							return Resources2{
+								&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeGSLB, nil)},
+							}, nil
+						},
 						ResourceDefBase: &ResourceDefBase{
 							TypeName: ResourceTypeGSLB.String(),
 							children: ResourceDefinitions{
 								&stubResourceDef{
 									computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 										return Resources2{
-											&stubResource2{resourceType: ResourceTypeServer},
+											&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
 										}, nil
 									},
 									ResourceDefBase: &ResourceDefBase{
@@ -304,7 +309,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 								&stubResourceDef{
 									computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 										return Resources2{
-											&stubResource2{resourceType: ResourceTypeServer},
+											&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
 										}, nil
 									},
 									ResourceDefBase: &ResourceDefBase{
@@ -312,11 +317,6 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 									},
 								},
 							},
-						},
-						computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
-							return Resources2{
-								&stubResource2{resourceType: ResourceTypeGSLB},
-							}, nil
 						},
 					},
 				},
@@ -341,30 +341,32 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 			want: &ResourceGroup2{
 				Resources: Resources2{
 					&stubResource2{
-						resourceType: ResourceTypeDNS,
-						children: Resources2{
+						ResourceBase2: NewResourceBase2(
+							ResourceTypeDNS,
+							nil,
 							&stubResource2{
-								resourceType: ResourceTypeEnhancedLoadBalancer,
-								children: Resources2{
-									&stubResource2{resourceType: ResourceTypeServer},
-									&stubResource2{resourceType: ResourceTypeServer},
-								},
+								ResourceBase2: NewResourceBase2(
+									ResourceTypeEnhancedLoadBalancer, nil,
+									&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
+									&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
+								),
 							},
 							&stubResource2{
-								resourceType: ResourceTypeEnhancedLoadBalancer,
-								children: Resources2{
-									&stubResource2{resourceType: ResourceTypeServer},
-									&stubResource2{resourceType: ResourceTypeServer},
-								},
+								ResourceBase2: NewResourceBase2(
+									ResourceTypeEnhancedLoadBalancer, nil,
+									&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
+									&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
+								),
 							},
-						},
+						),
 					},
 					&stubResource2{
-						resourceType: ResourceTypeGSLB,
-						children: Resources2{
-							&stubResource2{resourceType: ResourceTypeServer},
-							&stubResource2{resourceType: ResourceTypeServer},
-						},
+						ResourceBase2: NewResourceBase2(
+							ResourceTypeGSLB,
+							nil,
+							&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
+							&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
+						),
 					},
 				},
 			},


### PR DESCRIPTION
from #127 

親を持つResourceが生成したComputedには、Handlersに渡すパラメータを生成するために親ResourceのComputedが必要となる。
例: https://github.com/sacloud/autoscaler/blob/bec43b86f413837a0a32c564c8c4b9489117b9f8/protos/handler.proto#L102-L115

このためResource->親Resourceへの参照、Computed->Resourceへの参照を保持できるようにする。

イメージ: 
<img width="1286" alt="image" src="https://user-images.githubusercontent.com/1644816/122354138-ad4f6f00-cf8b-11eb-999b-a1737d88be55.png">

実装:

- Resource2にfunc `Parent()`を追加
- Resource2の実装に埋め込むためのstruct `ResourceBase2`を追加