### PR TITLE
Implements Server handling - ResourceDefServer/ResourceServer/ComputedServer

### DIFF
--- a/core/computed_server.go
+++ b/core/computed_server.go
@@ -1,0 +1,117 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"github.com/sacloud/autoscaler/handler"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+type computedServer2 struct {
+	instruction handler.ResourceInstructions
+	server      *sacloud.Server
+	zone        string
+	newCPU      int
+	newMemory   int
+	parent      Computed         // 親Resourceのcomputed
+	resource    *ResourceServer2 // 算出元のResourceへの参照
+}
+
+func (c *computedServer2) ID() string {
+	if c.server != nil {
+		return c.server.ID.String()
+	}
+	return ""
+}
+
+func (c *computedServer2) Type() ResourceTypes {
+	return ResourceTypeServer
+}
+
+func (c *computedServer2) Zone() string {
+	return c.zone
+}
+
+func (c *computedServer2) Instruction() handler.ResourceInstructions {
+	return c.instruction
+}
+
+func (c *computedServer2) parents() *handler.Parent {
+	return computedToParents(c.parent)
+}
+
+func (c *computedServer2) Current() *handler.Resource {
+	if c.server != nil {
+		return &handler.Resource{
+			Resource: &handler.Resource_Server{
+				Server: &handler.Server{
+					Id:              c.server.ID.String(),
+					Zone:            c.zone,
+					Core:            uint32(c.server.CPU),
+					Memory:          uint32(c.server.GetMemoryGB()),
+					DedicatedCpu:    c.server.ServerPlanCommitment.IsDedicatedCPU(),
+					AssignedNetwork: c.assignedNetwork(),
+					Parent:          c.parents(),
+					Option: &handler.ServerScalingOption{
+						ShutdownForce: c.resource.def.Option.ShutdownForce,
+					},
+				},
+			},
+		}
+	}
+	return nil
+}
+
+func (c *computedServer2) Desired() *handler.Resource {
+	if c.server != nil {
+		return &handler.Resource{
+			Resource: &handler.Resource_Server{
+				Server: &handler.Server{
+					Id:              c.server.ID.String(),
+					Zone:            c.zone,
+					Core:            uint32(c.newCPU),
+					Memory:          uint32(c.newMemory),
+					DedicatedCpu:    c.server.ServerPlanCommitment.IsDedicatedCPU(),
+					AssignedNetwork: c.assignedNetwork(),
+					Parent:          c.parents(),
+					Option: &handler.ServerScalingOption{
+						ShutdownForce: c.resource.def.Option.ShutdownForce,
+					},
+				},
+			},
+		}
+	}
+	return nil
+}
+
+func (c *computedServer2) assignedNetwork() []*handler.NetworkInfo {
+	var assignedNetwork []*handler.NetworkInfo
+	for i, nic := range c.server.Interfaces {
+		var ipAddress string
+		if nic.SwitchScope == types.Scopes.Shared {
+			ipAddress = nic.IPAddress
+		} else {
+			ipAddress = nic.UserIPAddress
+		}
+		assignedNetwork = append(assignedNetwork, &handler.NetworkInfo{
+			IpAddress: ipAddress,
+			Netmask:   uint32(nic.UserSubnetNetworkMaskLen),
+			Gateway:   nic.UserSubnetDefaultRoute,
+			Index:     uint32(i),
+		})
+	}
+	return assignedNetwork
+}

--- a/core/resource2.go
+++ b/core/resource2.go
@@ -14,26 +14,26 @@
 
 package core
 
-import "github.com/sacloud/libsacloud/v2/sacloud"
-
 // Resource2 Definitionから作られるResource
 //
 // TODO 現行Resourceとの切り替え時に名前変更する
 type Resource2 interface {
-	// Type リソースの型
-	Type() ResourceTypes
-
 	// Compute リクエストに沿った、希望する状態を算出する
 	//
-	// refreshがtrueの場合、さくらのクラウドAPIを用いて最新の状態に更新した上で処理を行う
-	Compute(ctx *RequestContext, apiClient sacloud.APICaller, refresh bool) (Computed, error)
+	// refreshがtrueの場合、さくらのクラウドAPIを用いて最新の状態を取得した上で処理を行う
+	// falseの場合はキャッシュされている結果を元に処理を行う
+	Compute(ctx *RequestContext, refresh bool) (Computed, error)
 
+	// Type リソースの型
+	Type() ResourceTypes
 	// Children 子リソース
 	Children() Resources2
 	// AppendChildren 子リソースを設定
 	AppendChildren(Resources2)
-
+	// Parent 親Resourceへの参照
 	Parent() Resource2
+	// SetParent 親Resourceを設定
+	SetParent(parent Resource2)
 }
 
 type Resources2 []Resource2
@@ -42,19 +42,6 @@ type ResourceBase2 struct {
 	resourceType ResourceTypes
 	parent       Resource2
 	children     Resources2
-}
-
-func NewResourceBase2(tp ResourceTypes, parent Resource2, children ...Resource2) *ResourceBase2 {
-	v := &ResourceBase2{
-		resourceType: tp,
-		parent:       parent,
-	}
-	for _, child := range children {
-		if child != nil {
-			v.children = append(v.children, child)
-		}
-	}
-	return v
 }
 
 func (r *ResourceBase2) Type() ResourceTypes {
@@ -71,4 +58,8 @@ func (r *ResourceBase2) AppendChildren(children Resources2) {
 
 func (r *ResourceBase2) Parent() Resource2 {
 	return r.parent
+}
+
+func (r *ResourceBase2) SetParent(parent Resource2) {
+	r.parent = parent
 }

--- a/core/resource2_stub_test.go
+++ b/core/resource2_stub_test.go
@@ -25,7 +25,7 @@ type stubResourceDef struct {
 	computeFunc func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error)
 }
 
-func (d *stubResourceDef) Validate(ctx context.Context, apiClient sacloud.APICaller) []error {
+func (d *stubResourceDef) Validate(_ context.Context, _ sacloud.APICaller) []error {
 	return nil
 }
 
@@ -39,12 +39,12 @@ func (d *stubResourceDef) Compute(ctx *RequestContext, apiClient sacloud.APICall
 // TODO リソース切り替え時に名前変更
 type stubResource2 struct {
 	*ResourceBase2
-	computeFunc func(ctx *RequestContext, apiClient sacloud.APICaller, refresh bool) (Computed, error)
+	computeFunc func(ctx *RequestContext, refresh bool) (Computed, error)
 }
 
-func (r *stubResource2) Compute(ctx *RequestContext, apiClient sacloud.APICaller, refresh bool) (Computed, error) {
+func (r *stubResource2) Compute(ctx *RequestContext, refresh bool) (Computed, error) {
 	if r.computeFunc != nil {
-		return r.computeFunc(ctx, apiClient, refresh)
+		return r.computeFunc(ctx, refresh)
 	}
 	return nil, nil
 }

--- a/core/resource_def_group.go
+++ b/core/resource_def_group.go
@@ -77,6 +77,10 @@ func (rg *ResourceDefGroup) buildResourceGroup(ctx *RequestContext, apiClient sa
 			return fmt.Errorf("ResourceDefinition with children must return one resource, but got multiple resources")
 		}
 
+		for _, r := range resources {
+			r.SetParent(parent)
+		}
+
 		// 親リソースが指定されてたらそちらに、以外はgroupに直接追加
 		if len(resources) > 0 {
 			if parent != nil {

--- a/core/resource_def_group_test.go
+++ b/core/resource_def_group_test.go
@@ -214,7 +214,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 					&stubResourceDef{
 						computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 							return Resources2{
-								&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeDNS, nil)},
+								&stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeDNS}},
 							}, nil
 						},
 						ResourceDefBase: &ResourceDefBase{
@@ -223,7 +223,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 								&stubResourceDef{
 									computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 										return Resources2{
-											&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeEnhancedLoadBalancer, nil)},
+											&stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeEnhancedLoadBalancer}},
 										}, nil
 									},
 									ResourceDefBase: &ResourceDefBase{
@@ -232,7 +232,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 											&stubResourceDef{
 												computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 													return Resources2{
-														&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
+														&stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeServer}},
 													}, nil
 												},
 												ResourceDefBase: &ResourceDefBase{
@@ -242,7 +242,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 											&stubResourceDef{
 												computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 													return Resources2{
-														&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
+														&stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeServer}},
 													}, nil
 												},
 												ResourceDefBase: &ResourceDefBase{
@@ -255,7 +255,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 								&stubResourceDef{
 									computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 										return Resources2{
-											&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeEnhancedLoadBalancer, nil)},
+											&stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeEnhancedLoadBalancer}},
 										}, nil
 									},
 									ResourceDefBase: &ResourceDefBase{
@@ -264,7 +264,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 											&stubResourceDef{
 												computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 													return Resources2{
-														&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
+														&stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeServer}},
 													}, nil
 												},
 												ResourceDefBase: &ResourceDefBase{
@@ -274,7 +274,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 											&stubResourceDef{
 												computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 													return Resources2{
-														&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
+														&stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeServer}},
 													}, nil
 												},
 												ResourceDefBase: &ResourceDefBase{
@@ -290,7 +290,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 					&stubResourceDef{
 						computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 							return Resources2{
-								&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeGSLB, nil)},
+								&stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeGSLB}},
 							}, nil
 						},
 						ResourceDefBase: &ResourceDefBase{
@@ -299,7 +299,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 								&stubResourceDef{
 									computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 										return Resources2{
-											&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
+											&stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeServer}},
 										}, nil
 									},
 									ResourceDefBase: &ResourceDefBase{
@@ -309,7 +309,7 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 								&stubResourceDef{
 									computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
 										return Resources2{
-											&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
+											&stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeServer}},
 										}, nil
 									},
 									ResourceDefBase: &ResourceDefBase{
@@ -338,38 +338,26 @@ func TestResourceDefGroup_ResourceGroup(t *testing.T) {
 				},
 				apiClient: test.APIClient,
 			},
-			want: &ResourceGroup2{
-				Resources: Resources2{
-					&stubResource2{
-						ResourceBase2: NewResourceBase2(
-							ResourceTypeDNS,
-							nil,
-							&stubResource2{
-								ResourceBase2: NewResourceBase2(
-									ResourceTypeEnhancedLoadBalancer, nil,
-									&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
-									&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
-								),
-							},
-							&stubResource2{
-								ResourceBase2: NewResourceBase2(
-									ResourceTypeEnhancedLoadBalancer, nil,
-									&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
-									&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
-								),
-							},
-						),
-					},
-					&stubResource2{
-						ResourceBase2: NewResourceBase2(
-							ResourceTypeGSLB,
-							nil,
-							&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
-							&stubResource2{ResourceBase2: NewResourceBase2(ResourceTypeServer, nil)},
-						),
-					},
-				},
-			},
+			want: func() *ResourceGroup2 {
+				dns := &stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeDNS}}
+				elb1 := &stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeEnhancedLoadBalancer, parent: dns}}
+				elb2 := &stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeEnhancedLoadBalancer, parent: dns}}
+				server1 := &stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeServer, parent: elb1}}
+				server2 := &stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeServer, parent: elb1}}
+				server3 := &stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeServer, parent: elb2}}
+				server4 := &stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeServer, parent: elb2}}
+
+				gslb := &stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeGSLB}}
+				server5 := &stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeServer, parent: gslb}}
+				server6 := &stubResource2{ResourceBase2: &ResourceBase2{resourceType: ResourceTypeServer, parent: gslb}}
+
+				dns.children = Resources2{elb1, elb2}
+				elb1.children = Resources2{server1, server2}
+				elb2.children = Resources2{server3, server4}
+				gslb.children = Resources2{server5, server6}
+
+				return &ResourceGroup2{Resources: Resources2{dns, gslb}}
+			}(),
 			wantErr: false,
 		},
 	}

--- a/core/resource_def_server.go
+++ b/core/resource_def_server.go
@@ -1,0 +1,146 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+type ResourceDefServer struct {
+	*ResourceDefBase `yaml:",inline"`
+	DedicatedCPU     bool                `yaml:"dedicated_cpu"`
+	Plans            []*ServerPlan       `yaml:"plans"`
+	Option           ServerScalingOption `yaml:"option"`
+}
+
+func (s *ResourceDefServer) resourcePlans() ResourcePlans {
+	if len(s.Plans) == 0 {
+		return DefaultServerPlans
+	}
+	var plans ResourcePlans
+	for _, p := range s.Plans {
+		plans = append(plans, p)
+	}
+	return plans
+}
+
+func (s *ResourceDefServer) Validate(ctx context.Context, apiClient sacloud.APICaller) []error {
+	errors := &multierror.Error{}
+
+	selector := s.Selector()
+	if selector == nil {
+		errors = multierror.Append(errors, fmt.Errorf("selector: required"))
+	} else {
+		if selector.Zone == "" {
+			errors = multierror.Append(errors, fmt.Errorf("selector.Zone: required"))
+		}
+	}
+
+	if errors.Len() == 0 {
+		if errs := s.validatePlans(ctx, apiClient); len(errs) > 0 {
+			errors = multierror.Append(errors, errs...)
+		}
+
+		if _, err := s.findCloudResources(ctx, apiClient); err != nil {
+			errors = multierror.Append(errors, err)
+		}
+	}
+
+	// set prefix
+	errors = multierror.Prefix(errors, fmt.Sprintf("resource=%s:", s.Type().String())).(*multierror.Error)
+	return errors.Errors
+}
+
+func (s *ResourceDefServer) validatePlans(ctx context.Context, apiClient sacloud.APICaller) []error {
+	if len(s.Plans) > 0 {
+		if len(s.Plans) == 1 {
+			return []error{fmt.Errorf("at least two plans must be specified")}
+		}
+
+		availablePlans, err := sacloud.NewServerPlanOp(apiClient).Find(ctx, s.Selector().Zone, nil)
+		if err != nil {
+			return []error{fmt.Errorf("validating server plan failed: %s", err)}
+		}
+
+		// for unique check: plan name
+		names := map[string]struct{}{}
+
+		errors := &multierror.Error{}
+		for _, p := range s.Plans {
+			if p.Name != "" {
+				if _, ok := names[p.Name]; ok {
+					errors = multierror.Append(errors, fmt.Errorf("plan name %q is duplicated", p.Name))
+				}
+				names[p.Name] = struct{}{}
+			}
+
+			exists := false
+			for _, available := range availablePlans.ServerPlans {
+				dedicatedCPU := available.Commitment == types.Commitments.DedicatedCPU
+				if available.Availability.IsAvailable() && dedicatedCPU == s.DedicatedCPU &&
+					available.CPU == p.Core && available.GetMemoryGB() == p.Memory {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				errors = multierror.Append(errors,
+					fmt.Errorf("plan{zone:%s, core:%d, memory:%d, dedicated_cpu:%t} not exists", s.Selector().Zone, p.Core, p.Memory, s.DedicatedCPU))
+			}
+		}
+
+		return errors.Errors
+	}
+	return nil
+}
+
+func (s *ResourceDefServer) Compute(ctx *RequestContext, apiClient sacloud.APICaller) (Resources2, error) {
+	cloudResources, err := s.findCloudResources(ctx, apiClient)
+	if err != nil {
+		return nil, err
+	}
+
+	var resources Resources2
+	for _, server := range cloudResources {
+		r, err := NewResourceServer(ctx, apiClient, s, s.Selector().Zone, server)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, r)
+	}
+	return resources, nil
+}
+
+func (s *ResourceDefServer) findCloudResources(ctx context.Context, apiClient sacloud.APICaller) ([]*sacloud.Server, error) {
+	serverOp := sacloud.NewServerOp(apiClient)
+	selector := s.Selector()
+
+	// TODO セレクターに複数のゾーンを指定可能にしたらここも修正
+
+	found, err := serverOp.Find(ctx, selector.Zone, selector.findCondition())
+	if err != nil {
+		return nil, fmt.Errorf("computing status failed: %s", err)
+	}
+	if len(found.Servers) == 0 {
+		return nil, fmt.Errorf("resource not found with selector: %s", selector.String())
+	}
+
+	return found.Servers, nil
+}

--- a/core/resource_def_server_test.go
+++ b/core/resource_def_server_test.go
@@ -1,0 +1,118 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sacloud/autoscaler/test"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceDefServer_Validate(t *testing.T) {
+	defer initTestServer(t)()
+
+	t.Run("returns error if selector is empty", func(t *testing.T) {
+		empty := &Server{
+			ResourceBase: &ResourceBase{TypeName: "Server"},
+		}
+		errs := empty.Validate(context.Background(), test.APIClient)
+		require.Len(t, errs, 1)
+		require.EqualError(t, errs[0], "resource=Server: selector: required")
+	})
+
+	t.Run("returns error if selector.Zone is empty", func(t *testing.T) {
+		empty := &Server{
+			ResourceBase: &ResourceBase{
+				TypeName:       "Server",
+				TargetSelector: &ResourceSelector{},
+			},
+		}
+		errs := empty.Validate(context.Background(), test.APIClient)
+		require.Len(t, errs, 1)
+		require.EqualError(t, errs[0], "resource=Server: selector.Zone: required")
+	})
+
+	t.Run("returns error if servers were not found", func(t *testing.T) {
+		empty := &Server{
+			ResourceBase: &ResourceBase{
+				TypeName: "Server",
+				TargetSelector: &ResourceSelector{
+					Zone:  "is1a",
+					Names: []string{"server-not-found"},
+				},
+			},
+		}
+		errs := empty.Validate(context.Background(), test.APIClient)
+		require.Len(t, errs, 1)
+		require.EqualError(t, errs[0], "resource=Server: resource not found with selector: ID: , Names: [server-not-found], Zone: is1a")
+	})
+}
+
+func TestResourceDefServer_Compute(t *testing.T) {
+	defer initTestServer(t)()
+
+	type fields struct {
+		ResourceDefBase *ResourceDefBase
+	}
+	type args struct {
+		ctx       *RequestContext
+		apiClient sacloud.APICaller
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    Resources2
+		wantErr bool
+	}{
+		{
+			name: "simple",
+			fields: fields{
+				ResourceDefBase: &ResourceDefBase{
+					TypeName: ResourceTypeServer.String(),
+					TargetSelector: &ResourceSelector{
+						Names: []string{"test-server"},
+						Zone:  test.Zone,
+					},
+				},
+			},
+			args: args{
+				ctx: &RequestContext{
+					ctx:    context.Background(),
+					logger: test.Logger,
+				},
+				apiClient: test.APIClient,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &ResourceDefServer{
+				ResourceDefBase: tt.fields.ResourceDefBase,
+			}
+			got, err := s.Compute(tt.args.ctx, tt.args.apiClient)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Compute() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.Len(t, got, 1)
+		})
+	}
+}

--- a/core/resource_server2.go
+++ b/core/resource_server2.go
@@ -1,0 +1,146 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"fmt"
+
+	"github.com/sacloud/autoscaler/handler"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
+
+type ResourceServer2 struct {
+	*ResourceBase2
+
+	apiClient sacloud.APICaller
+	server    *sacloud.Server
+	def       *ResourceDefServer
+	zone      string
+}
+
+func NewResourceServer(ctx *RequestContext, apiClient sacloud.APICaller, def *ResourceDefServer, zone string, server *sacloud.Server) (*ResourceServer2, error) {
+	resource := &ResourceServer2{
+		ResourceBase2: &ResourceBase2{resourceType: ResourceTypeServer},
+		apiClient:     apiClient,
+		zone:          zone,
+		server:        server,
+		def:           def,
+	}
+	if err := resource.setResourceIDTag(ctx); err != nil {
+		return nil, err
+	}
+	return resource, nil
+}
+
+func (r *ResourceServer2) Compute(ctx *RequestContext, refresh bool) (Computed, error) {
+	if refresh {
+		if err := r.refresh(ctx); err != nil {
+			return nil, err
+		}
+	}
+	var parent Computed
+	if r.parent != nil {
+		pc, err := r.parent.Compute(ctx, false)
+		if err != nil {
+			return nil, err
+		}
+		parent = pc
+	}
+
+	computed := &computedServer2{
+		instruction: handler.ResourceInstructions_NOOP,
+		server:      &sacloud.Server{},
+		zone:        r.zone,
+		resource:    r,
+		parent:      parent,
+	}
+	if err := mapconvDecoder.ConvertTo(r.server, computed.server); err != nil {
+		return nil, fmt.Errorf("computing desired state failed: %s", err)
+	}
+
+	plan, err := r.desiredPlan(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("computing desired plan failed: %s", err)
+	}
+
+	if plan != nil {
+		computed.newCPU = plan.Core
+		computed.newMemory = plan.Memory
+		computed.instruction = handler.ResourceInstructions_UPDATE
+	}
+	return computed, nil
+}
+
+func (r *ResourceServer2) desiredPlan(ctx *RequestContext) (*ServerPlan, error) {
+	plans := r.def.resourcePlans()
+	plan, err := desiredPlan(ctx, r.server, plans)
+	if err != nil {
+		return nil, err
+	}
+	if plan != nil {
+		if v, ok := plan.(*ServerPlan); ok {
+			return v, nil
+		}
+		return nil, fmt.Errorf("invalid plan: %#v", plan)
+	}
+	return nil, nil
+}
+
+func (r *ResourceServer2) setResourceIDTag(ctx *RequestContext) error {
+	tags, changed := SetupTagsWithResourceID(r.server.Tags, r.server.ID)
+	if changed {
+		serverOp := sacloud.NewServerOp(r.apiClient)
+		updated, err := serverOp.Update(ctx, r.zone, r.server.ID, &sacloud.ServerUpdateRequest{
+			Name:            r.server.Name,
+			Description:     r.server.Description,
+			Tags:            tags,
+			IconID:          r.server.IconID,
+			PrivateHostID:   r.server.PrivateHostID,
+			InterfaceDriver: r.server.InterfaceDriver,
+		})
+		if err != nil {
+			return err
+		}
+		r.server = updated
+	}
+	return nil
+}
+
+func (r *ResourceServer2) refresh(ctx *RequestContext) error {
+	serverOp := sacloud.NewServerOp(r.apiClient)
+
+	// まずキャッシュしているリソースのIDで検索
+	server, err := serverOp.Read(ctx, r.zone, r.server.ID)
+	if err != nil {
+		if sacloud.IsNotFoundError(err) {
+			// 見つからなかったらIDマーカータグを元に検索
+			found, err := serverOp.Find(ctx, r.zone, FindConditionWithResourceIDTag(r.server.ID))
+			if err != nil {
+				return err
+			}
+			if len(found.Servers) == 0 {
+				return fmt.Errorf("server not found with: Filter='%s'", resourceIDMarkerTag(r.server.ID))
+			}
+			if len(found.Servers) > 1 {
+				return fmt.Errorf("invalid state: found multiple server with: Filter='%s'", resourceIDMarkerTag(r.server.ID))
+			}
+			server = found.Servers[0]
+		} else {
+			return err
+		}
+	}
+	r.server = server
+	return r.setResourceIDTag(ctx)
+}

--- a/core/resource_server2_test.go
+++ b/core/resource_server2_test.go
@@ -1,0 +1,208 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/sacloud/autoscaler/handler"
+	"github.com/sacloud/autoscaler/test"
+	"github.com/sacloud/libsacloud/v2/pkg/size"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/stretchr/testify/require"
+)
+
+func initTestResourceServer(t *testing.T) *sacloud.Server {
+	serverOp := sacloud.NewServerOp(test.APIClient)
+	server, err := serverOp.Create(context.Background(), test.Zone, &sacloud.ServerCreateRequest{
+		CPU:                  2,
+		MemoryMB:             4 * size.GiB,
+		ServerPlanCommitment: types.Commitments.Standard,
+		ServerPlanGeneration: types.PlanGenerations.Default,
+		ConnectedSwitches:    nil,
+		InterfaceDriver:      types.InterfaceDrivers.VirtIO,
+		Name:                 "test-server",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return server
+}
+
+func TestResourceServer_New_Refresh(t *testing.T) {
+	ctx := testContext()
+	server := initTestResourceServer(t)
+
+	def := &ResourceDefServer{
+		ResourceDefBase: &ResourceDefBase{
+			TypeName: "",
+			TargetSelector: &ResourceSelector{
+				ID:    0,
+				Names: nil,
+				Zone:  "",
+			},
+			children: nil,
+		},
+		DedicatedCPU: false,
+		Plans:        nil,
+		Option: ServerScalingOption{
+			ShutdownForce: false,
+		},
+	}
+
+	// Newした時にIDマーカータグが付与されるはず
+	resource, err := NewResourceServer(ctx, test.APIClient, def, test.Zone, server)
+	require.NoError(t, err)
+	require.NotNil(t, resource)
+
+	serverOp := sacloud.NewServerOp(test.APIClient)
+
+	server, err = serverOp.Read(ctx, test.Zone, server.ID)
+	require.NoError(t, err)
+	require.EqualValues(t, types.Tags{resourceIDMarkerTag(server.ID)}, server.Tags)
+
+	// IDを変えるためにプラン変更を実施
+	updated, err := serverOp.ChangePlan(ctx, test.Zone, server.ID, &sacloud.ServerChangePlanRequest{
+		CPU:                  1,
+		MemoryMB:             2 * size.GiB,
+		ServerPlanGeneration: types.PlanGenerations.Default,
+		ServerPlanCommitment: types.Commitments.Standard,
+	})
+	require.NoError(t, err)
+
+	// refresh実施
+	_, err = resource.Compute(ctx, true)
+	require.NoError(t, err)
+
+	server, err = serverOp.Read(ctx, test.Zone, updated.ID)
+	require.NoError(t, err)
+	require.EqualValues(t, types.Tags{resourceIDMarkerTag(updated.ID)}, server.Tags)
+
+	// cleanup
+	if err := serverOp.Delete(ctx, test.Zone, updated.ID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResourceServer2_Compute(t *testing.T) {
+	server := initTestResourceServer(t)
+	defer func() {
+		if err := sacloud.NewServerOp(test.APIClient).Delete(context.Background(), test.Zone, server.ID); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	def := &ResourceDefServer{
+		ResourceDefBase: &ResourceDefBase{
+			TypeName: "",
+			TargetSelector: &ResourceSelector{
+				ID:    0,
+				Names: nil,
+				Zone:  "",
+			},
+			children: nil,
+		},
+		DedicatedCPU: false,
+		Plans: []*ServerPlan{
+			{Core: 1, Memory: 1, Name: "plan1"},
+			{Core: 2, Memory: 4, Name: "plan2"},
+			{Core: 4, Memory: 8, Name: "plan3"},
+		},
+		Option: ServerScalingOption{
+			ShutdownForce: false,
+		},
+	}
+	resource := &ResourceServer2{
+		ResourceBase2: &ResourceBase2{
+			resourceType: ResourceTypeServer,
+		},
+		apiClient: test.APIClient,
+		server:    server,
+		def:       def,
+		zone:      test.Zone,
+	}
+
+	type args struct {
+		ctx     *RequestContext
+		refresh bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Computed
+		wantErr bool
+	}{
+		{
+			name: "up",
+			args: args{
+				ctx: NewRequestContext(context.Background(), &requestInfo{
+					requestType:       requestTypeUp,
+					source:            "default",
+					action:            "default",
+					resourceGroupName: "default",
+					desiredStateName:  "",
+				}, test.Logger),
+				refresh: false,
+			},
+			want: &computedServer2{
+				instruction: handler.ResourceInstructions_UPDATE,
+				server:      server,
+				zone:        test.Zone,
+				newCPU:      4,
+				newMemory:   8,
+				parent:      nil,
+				resource:    resource,
+			},
+			wantErr: false,
+		},
+		{
+			name: "down",
+			args: args{
+				ctx: NewRequestContext(context.Background(), &requestInfo{
+					requestType:       requestTypeDown,
+					source:            "default",
+					action:            "default",
+					resourceGroupName: "default",
+					desiredStateName:  "",
+				}, test.Logger),
+				refresh: false,
+			},
+			want: &computedServer2{
+				instruction: handler.ResourceInstructions_UPDATE,
+				server:      server,
+				zone:        test.Zone,
+				newCPU:      1,
+				newMemory:   1,
+				parent:      nil,
+				resource:    resource,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resource.Compute(tt.args.ctx, tt.args.refresh)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Compute() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Compute() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/resource_tags.go
+++ b/core/resource_tags.go
@@ -1,0 +1,75 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/search"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+const resourceIDMarkerTagName = "@autoscaler.id"
+
+// resourceIDMarkerTag さくらのクラウド上のリソースに付与するIDマーカータグ
+//
+// プラン変更時のリソースID変更に追随するために現在のIDをタグとして保持しておくためのもの
+func resourceIDMarkerTag(id types.ID) string {
+	return fmt.Sprintf("%s=%s", resourceIDMarkerTagName, id.String())
+}
+
+// SetupTagsWithResourceID さくらのクラウド上のリソースのタグをセットアップする
+//
+// 古いIDマーカータグがあれば削除し、指定のIDのIDマーカータグが付与されていなければ追加する
+// タグに変更があった場合は2番目の戻り値としてtrueを返す
+func SetupTagsWithResourceID(current types.Tags, id types.ID) (tags types.Tags, changed bool) {
+	idTag := resourceIDMarkerTag(id)
+
+	for _, t := range current {
+		// 古いタグが残っていたら削除
+		if strings.HasPrefix(t, resourceIDMarkerTagName) && t != idTag {
+			changed = true
+		} else {
+			tags = append(tags, t)
+		}
+	}
+
+	if !existTag(tags, idTag) {
+		tags = append(tags, idTag)
+		changed = true
+	}
+
+	return tags, changed
+}
+
+// FindConditionWithResourceIDTag IDマーカータグで検索するためのAPIパラメータを作成する
+func FindConditionWithResourceIDTag(id types.ID) *sacloud.FindCondition {
+	return &sacloud.FindCondition{
+		Filter: search.Filter{
+			search.Key("Tags.Name"): search.TagsAndEqual(resourceIDMarkerTag(id)),
+		},
+	}
+}
+
+func existTag(tags types.Tags, tag string) bool {
+	for _, t := range tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
from #127

Resource `Server`を分割&実装

- ResourceDefServer: セレクタを元にさくらのクラウドAPIで該当サーバを検索、ResourceServerを作成する
- ResourceServer: さくらのクラウドのサーバの情報を保持し、ComputedServerを算出する
- ComputedServer: ハンドラに渡される値オブジェクト

基本的には既存の`core.Server`の処理を移植している。  
追加で以下のIDマーカータグの付与処理とリフレッシュ処理を実装している。

### IDマーカータグの付与の実装

ResourceServerは以下のシグニチャで行う。

```go
func NewResourceServer(ctx *RequestContext, apiClient sacloud.APICaller, def *ResourceDefServer, zone string, server *sacloud.Server) (*ResourceServer2, error)
```

この際、さくらのクラウド上のサーバにIDマーカータグの付与を行う。
IDマーカータグは`@autoscaler.id=nnn`という形式で、nnnには現在のリソースID(さくらのクラウド上のリソースのID)となる。  

IDマーカータグ付与は以下の処理を行う。

- 既存のIDマーカータグが存在すれば(nnnの値に関わらず)削除する
- 現在のIDに対応するIDマーカータグがない場合は追加する

### リフレッシュ処理の実装

Compute()は以下のシグニチャを持つ。

```go
func Compute(ctx *RequestContext, refresh bool) (Computed, error)
```

引数の`refresh`がtrueの場合はキャッシュしているリソース情報をリフレッシュする。
リフレッシュ処理は以下の処理を行う。

- キャッシュしているリソースのIDを条件にさくらのクラウドAPIで検索
- ヒットしなかった場合はIDマーカータグを条件としてさくらのクラウドAPIで検索
- ヒットしたらIDマーカータグを更新した上で自身がキャッシュしているサーバ情報を置き換え
- ヒットしなかったらエラー