### PR TITLE
Allow multiple zone

### DIFF
--- a/commands/core/example/example.yaml
+++ b/commands/core/example/example.yaml
@@ -25,7 +25,7 @@ resources:
           id: 123456789012
           # names: ["example"]
 
-          zone: "is1a"
+          zones: ["is1a"]
         # プラン(省略可)、省略した場合はデフォルトのプラン範囲内でスケールする
         plans:
           - core: 1
@@ -57,11 +57,11 @@ resources:
       #     - type: Server
       #       selector:
       #         names: ["example1"]
-      #         zone: "is1a"
+      #         zones: ["is1a"]
       #     - type: Server
       #       selector:
       #         names: ["example2"]
-      #         zone: "is1a"
+      #         zones: ["is1a"]
 
       # GSLB + サーバ(垂直スケール)
       # サーバの垂直スケール時にGSLBからのデタッチ/アタッチを行う
@@ -72,17 +72,17 @@ resources:
       #     - type: Server
       #       selector:
       #         names: ["example1"]
-      #         zone: "is1a"
+      #         zones: ["is1a"]
       #     - type: Server
       #       selector:
       #         names: ["example2"]
-      #         zone: "is1a"
+      #         zones: ["is1a"]
 
       # ルータ(垂直スケール)
       # - type: Router
       #   selector:
       #     names: ["example"]
-      #     zone: "is1a"
+      #     zones: ["is1a"]
       #   # プラン(省略可)
       #   plans:
       #     - band_width: 100

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -62,7 +62,7 @@ func TestConfig_Load(t *testing.T) {
 								TypeName: "Server",
 								TargetSelector: &ResourceSelector{
 									Names: []string{"test-name"},
-									Zone:  "is1a",
+									Zones: []string{"is1a"},
 								},
 							},
 							DedicatedCPU: true,
@@ -89,7 +89,7 @@ resources:
       - type: Server
         selector:
           names: ["test-name"]
-          zone: "is1a"
+          zones: ["is1a"]
         dedicated_cpu: true
 autoscaler:
   cooldown: 30

--- a/core/resource_def_dns.go
+++ b/core/resource_def_dns.go
@@ -29,14 +29,9 @@ type ResourceDefDNS struct {
 
 func (d *ResourceDefDNS) Validate(ctx context.Context, apiClient sacloud.APICaller) []error {
 	errors := &multierror.Error{}
-	selector := d.Selector()
-	if selector == nil {
-		errors = multierror.Append(errors, fmt.Errorf("selector: required"))
+	if err := d.Selector().Validate(false); err != nil {
+		errors = multierror.Append(errors, err)
 	} else {
-		if selector.Zone != "" {
-			errors = multierror.Append(errors, fmt.Errorf("selector.Zone: can not be specified for this resource"))
-		}
-
 		resources, err := d.findCloudResources(ctx, apiClient)
 		if err != nil {
 			errors = multierror.Append(errors, err)

--- a/core/resource_def_dns_test.go
+++ b/core/resource_def_dns_test.go
@@ -44,7 +44,7 @@ func TestResourceDefDNS_Validate(t *testing.T) {
 				ResourceDefBase: &ResourceDefBase{
 					TypeName: ResourceTypeDNS.String(),
 					TargetSelector: &ResourceSelector{
-						Zone: "is1a",
+						Zones: []string{"is1a"},
 					},
 				},
 			},

--- a/core/resource_def_elb.go
+++ b/core/resource_def_elb.go
@@ -54,14 +54,9 @@ func (d *ResourceDefELB) resourcePlans() ResourcePlans {
 
 func (d *ResourceDefELB) Validate(ctx context.Context, apiClient sacloud.APICaller) []error {
 	errors := &multierror.Error{}
-	selector := d.Selector()
-	if selector == nil {
-		errors = multierror.Append(errors, fmt.Errorf("selector: required"))
+	if err := d.Selector().Validate(false); err != nil {
+		errors = multierror.Append(errors, err)
 	} else {
-		if selector.Zone != "" {
-			errors = multierror.Append(errors, fmt.Errorf("selector.Zone: can not be specified for this resource"))
-		}
-
 		if errs := d.validatePlans(ctx, apiClient); len(errs) > 0 {
 			errors = multierror.Append(errors, errs...)
 		}

--- a/core/resource_def_groups_test.go
+++ b/core/resource_def_groups_test.go
@@ -46,7 +46,7 @@ func TestResourceDefGroups_UnmarshalYAML(t *testing.T) {
 						TypeName: "DNS",
 						TargetSelector: &ResourceSelector{
 							Names: []string{"test-name"},
-							Zone:  "is1a",
+							Zones: []string{"is1a"},
 						},
 					},
 				}
@@ -55,7 +55,7 @@ func TestResourceDefGroups_UnmarshalYAML(t *testing.T) {
 						TypeName: "Server",
 						TargetSelector: &ResourceSelector{
 							Names: []string{"test-child"},
-							Zone:  "is1a",
+							Zones: []string{"is1a"},
 						},
 					},
 				}
@@ -68,7 +68,7 @@ func TestResourceDefGroups_UnmarshalYAML(t *testing.T) {
 							TypeName: "Server",
 							TargetSelector: &ResourceSelector{
 								Names: []string{"test-name"},
-								Zone:  "is1a",
+								Zones: []string{"is1a"},
 							},
 						},
 						DedicatedCPU: true,
@@ -79,7 +79,7 @@ func TestResourceDefGroups_UnmarshalYAML(t *testing.T) {
 							TypeName: "GSLB",
 							TargetSelector: &ResourceSelector{
 								Names: []string{"test-name"},
-								Zone:  "is1a",
+								Zones: []string{"is1a"},
 							},
 						},
 					},
@@ -88,7 +88,7 @@ func TestResourceDefGroups_UnmarshalYAML(t *testing.T) {
 							TypeName: "EnhancedLoadBalancer",
 							TargetSelector: &ResourceSelector{
 								Names: []string{"test-name"},
-								Zone:  "is1a",
+								Zones: []string{"is1a"},
 							},
 						},
 					},
@@ -103,25 +103,25 @@ web:
     - type: Server
       selector:
         names: ["test-name"]
-        zone: "is1a"
+        zones: ["is1a"]
       dedicated_cpu: true
     - type: DNS
       selector:
         names: ["test-name"]
-        zone: "is1a"
+        zones: ["is1a"]
       resources:
         - type: Server
           selector:
             names: ["test-child"]
-            zone: "is1a"
+            zones: ["is1a"]
     - type: GSLB 
       selector:
         names: ["test-name"]
-        zone: "is1a"
+        zones: ["is1a"]
     - type: ELB
       selector:
         names: ["test-name"]
-        zone: "is1a"
+        zones: ["is1a"]
   actions:
     foobar:
       - handler1

--- a/core/resource_def_gslb.go
+++ b/core/resource_def_gslb.go
@@ -29,14 +29,9 @@ type ResourceDefGSLB struct {
 
 func (d *ResourceDefGSLB) Validate(ctx context.Context, apiClient sacloud.APICaller) []error {
 	errors := &multierror.Error{}
-	selector := d.Selector()
-	if selector == nil {
-		errors = multierror.Append(errors, fmt.Errorf("selector: required"))
+	if err := d.Selector().Validate(false); err != nil {
+		errors = multierror.Append(errors, err)
 	} else {
-		if selector.Zone != "" {
-			errors = multierror.Append(errors, fmt.Errorf("selector.Zone: can not be specified for this resource"))
-		}
-
 		resources, err := d.findCloudResources(ctx, apiClient)
 		if err != nil {
 			errors = multierror.Append(errors, err)

--- a/core/resource_def_server_test.go
+++ b/core/resource_def_server_test.go
@@ -38,16 +38,18 @@ func TestResourceDefServer_Validate(t *testing.T) {
 		require.EqualError(t, errs[0], "resource=Server: selector: required")
 	})
 
-	t.Run("returns error if selector.Zone is empty", func(t *testing.T) {
+	t.Run("returns error if selector.Zones is empty", func(t *testing.T) {
 		empty := &ResourceDefServer{
 			ResourceDefBase: &ResourceDefBase{
-				TypeName:       "Server",
-				TargetSelector: &ResourceSelector{},
+				TypeName: "Server",
+				TargetSelector: &ResourceSelector{
+					Names: []string{"test"},
+				},
 			},
 		}
 		errs := empty.Validate(context.Background(), test.APIClient)
 		require.Len(t, errs, 1)
-		require.EqualError(t, errs[0], "resource=Server: selector.Zone: required")
+		require.EqualError(t, errs[0], "resource=Server: selector.Zones: required")
 	})
 
 	t.Run("returns error if servers were not found", func(t *testing.T) {
@@ -55,14 +57,14 @@ func TestResourceDefServer_Validate(t *testing.T) {
 			ResourceDefBase: &ResourceDefBase{
 				TypeName: "Server",
 				TargetSelector: &ResourceSelector{
-					Zone:  "is1a",
+					Zones: []string{"is1a"},
 					Names: []string{"server-not-found"},
 				},
 			},
 		}
 		errs := empty.Validate(context.Background(), test.APIClient)
 		require.Len(t, errs, 1)
-		require.EqualError(t, errs[0], "resource=Server: resource not found with selector: ID: , Names: [server-not-found], Zone: is1a")
+		require.EqualError(t, errs[0], "resource=Server: resource not found with selector: ID: , Names: [server-not-found], Zones: [is1a]")
 	})
 }
 
@@ -91,7 +93,7 @@ func TestResourceDefServer_Compute(t *testing.T) {
 					TypeName: ResourceTypeServer.String(),
 					TargetSelector: &ResourceSelector{
 						Names: []string{"test-server"},
-						Zone:  test.Zone,
+						Zones: []string{test.Zone},
 					},
 				},
 			},
@@ -132,8 +134,8 @@ func TestServer_ComputedWithResource(t *testing.T) {
 			ResourceDefBase: &ResourceDefBase{
 				TypeName: "Server",
 				TargetSelector: &ResourceSelector{
-					ID:   123456789012,
-					Zone: test.Zone,
+					ID:    123456789012,
+					Zones: []string{test.Zone},
 				},
 			},
 		}
@@ -148,7 +150,7 @@ func TestServer_ComputedWithResource(t *testing.T) {
 				TypeName: "Server",
 				TargetSelector: &ResourceSelector{
 					Names: []string{"test-server"},
-					Zone:  test.Zone,
+					Zones: []string{test.Zone},
 				},
 			},
 			Plans: []*ServerPlan{
@@ -183,7 +185,7 @@ func TestServer_ComputedWithResource(t *testing.T) {
 				TypeName: "Server",
 				TargetSelector: &ResourceSelector{
 					Names: []string{"test-server"},
-					Zone:  test.Zone,
+					Zones: []string{test.Zone},
 				},
 			},
 			Plans: []*ServerPlan{

--- a/core/resource_definition_test.go
+++ b/core/resource_definition_test.go
@@ -1,0 +1,102 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+func TestResourceSelector_Validate(t *testing.T) {
+	type fields struct {
+		ID    types.ID
+		Names []string
+		Zones []string
+	}
+	type args struct {
+		requireZone bool
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "returns error when selector is empty",
+			fields:  fields{},
+			args:    args{requireZone: false},
+			wantErr: true,
+		},
+		{
+			name: "returns error when both of ID and Names are specified",
+			fields: fields{
+				ID:    1,
+				Names: []string{"1"},
+			},
+			args:    args{requireZone: false},
+			wantErr: true,
+		},
+		{
+			name: "returns error when zones are specified with requireZone:false",
+			fields: fields{
+				ID:    1,
+				Zones: []string{"is1a"},
+			},
+			args:    args{requireZone: false},
+			wantErr: true,
+		},
+		{
+			name: "returns no error when zones are specified with requireZone:true",
+			fields: fields{
+				ID:    1,
+				Zones: []string{"is1a"},
+			},
+			args:    args{requireZone: true},
+			wantErr: false,
+		},
+		{
+			name: "returns error when invalid zone value is specified",
+			fields: fields{
+				ID:    1,
+				Zones: []string{"invalid"},
+			},
+			args:    args{requireZone: true},
+			wantErr: true,
+		},
+		{
+			name: "returns error when empty zone name is specified",
+			fields: fields{
+				ID:    1,
+				Zones: []string{"invalid"},
+			},
+			args:    args{requireZone: true},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rs := &ResourceSelector{
+				ID:    tt.fields.ID,
+				Names: tt.fields.Names,
+				Zones: tt.fields.Zones,
+			}
+			if err := rs.Validate(tt.args.requireZone); (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/core/resource_definitions_test.go
+++ b/core/resource_definitions_test.go
@@ -57,7 +57,6 @@ func TestResourceDefinitions_HandleAll_havingChildrenDefinitionReturnsMultipleRe
 	}
 	err := defs.HandleAll(ctx, test.APIClient, noopHandlers)
 	require.True(t, err != nil)
-	t.Log(err)
 }
 
 func TestResourceDefinitions_HandleAll_withActualResource(t *testing.T) {
@@ -72,7 +71,7 @@ func TestResourceDefinitions_HandleAll_withActualResource(t *testing.T) {
 			TypeName: "Server",
 			TargetSelector: &ResourceSelector{
 				Names: []string{"test-server"},
-				Zone:  test.Zone,
+				Zones: []string{test.Zone},
 			},
 		},
 	}

--- a/core/resource_server_test.go
+++ b/core/resource_server_test.go
@@ -54,7 +54,7 @@ func TestResourceServer_New_Refresh(t *testing.T) {
 			TargetSelector: &ResourceSelector{
 				ID:    0,
 				Names: nil,
-				Zone:  "",
+				Zones: []string{},
 			},
 			children: nil,
 		},
@@ -112,7 +112,7 @@ func TestResourceServer2_Compute(t *testing.T) {
 			TargetSelector: &ResourceSelector{
 				ID:    0,
 				Names: nil,
-				Zone:  "",
+				Zones: []string{},
 			},
 			children: nil,
 		},


### PR DESCRIPTION
closes #139 

コンフィギュレーションでリソースを定義する際に複数のゾーンを指定可能にする。

```yaml
resources:
  example:
    resources:
      # 名前にexampleが含まれるis1a or is1bのサーバ
      - type: Server
        selector:
          names: ["example"]
          zones: ["is1a", "is1b"]
```