### PR TITLE
Inputs returns JSON response

### DIFF
--- a/inputs/inputs.go
+++ b/inputs/inputs.go
@@ -100,7 +100,9 @@ func (s *server) handle(requestType string, w http.ResponseWriter, req *http.Req
 	}
 	if scalingReq == nil {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ignored")) // nolint
+		w.WriteHeader(http.StatusOK)
+		w.Header().Add("Content-Type", "application/json")
+		w.Write([]byte(`{"message":"ignored"}`)) // nolint
 		return
 	}
 
@@ -124,9 +126,9 @@ func (s *server) handle(requestType string, w http.ResponseWriter, req *http.Req
 		return
 	}
 
-	w.Header().Add("Content-Type", "text/plain")
+	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(fmt.Sprintf("scaling-job-id:%s, status:%s, message:%s", res.ScalingJobId, res.Status, res.Message))) // nolint
+	w.Write([]byte(fmt.Sprintf(`{"id":"%s", "status":"%s", "message":"%s"}`, res.ScalingJobId, res.Status, res.Message))) // nolint
 }
 
 func (s *server) parseRequest(requestType string, req *http.Request) (*ScalingRequest, error) {


### PR DESCRIPTION
closes #152 

レスポンスをJSONにする。

レスポンスボディ例:

```json
{"id":"default-default-default", "status":"JOB_RUNNING", "message":""}
```

```json
{"message":"ignored"}
```

Note: `/healthz`エンドポイントは従来通り(`plain/text`で`ok`と返す)