### PR TITLE
Added 'core resources' subcommand

### DIFF
--- a/commands/core/core.go
+++ b/commands/core/core.go
@@ -17,6 +17,7 @@ package core
 import (
 	"github.com/sacloud/autoscaler/commands/core/example"
 	"github.com/sacloud/autoscaler/commands/core/handlers"
+	"github.com/sacloud/autoscaler/commands/core/resources"
 	"github.com/sacloud/autoscaler/commands/core/start"
 	"github.com/sacloud/autoscaler/commands/core/validate"
 	"github.com/spf13/cobra"
@@ -34,6 +35,7 @@ var subCommands = []*cobra.Command{
 	start.Command,
 	handlers.Command,
 	validate.Command,
+	resources.Command,
 }
 
 func init() {

--- a/commands/core/resources/cmd.go
+++ b/commands/core/resources/cmd.go
@@ -1,0 +1,56 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/autoscaler/validate"
+
+	"github.com/sacloud/autoscaler/commands/flags"
+	"github.com/sacloud/autoscaler/core"
+	"github.com/sacloud/autoscaler/defaults"
+	"github.com/spf13/cobra"
+)
+
+var Command = &cobra.Command{
+	Use:   "resources [flags]...",
+	Short: "list target resources",
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return validate.Struct(param)
+	},
+	RunE: run,
+}
+
+type parameter struct {
+	ConfigPath string `name:"--config" validate:"required,file"`
+}
+
+var param = &parameter{
+	ConfigPath: defaults.CoreConfigPath,
+}
+
+func init() {
+	Command.Flags().StringVar(&param.ConfigPath, "config", param.ConfigPath, "File path of configuration of AutoScaler Core")
+}
+func run(cmd *cobra.Command, args []string) error {
+	tree, err := core.ResourcesTree(context.Background(), "", param.ConfigPath, flags.NewLogger())
+	if err != nil {
+		return err
+	}
+	fmt.Println("\n" + tree + "\n")
+	return nil
+}

--- a/core/graph.go
+++ b/core/graph.go
@@ -1,0 +1,103 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/shivamMg/ppds/tree"
+)
+
+type Graph struct {
+	defGroups *ResourceDefGroups
+	children  []tree.Node
+}
+
+func NewGraph(defGroups *ResourceDefGroups) *Graph {
+	return &Graph{
+		defGroups: defGroups,
+	}
+}
+
+func (n *Graph) Data() interface{} {
+	return "Sacloud AutoScaler"
+}
+
+func (n *Graph) Children() []tree.Node {
+	return n.children
+}
+
+func (g *Graph) Tree(ctx *RequestContext, apiClient sacloud.APICaller) (string, error) {
+	g.children = []tree.Node{}
+	for _, group := range g.defGroups.All() {
+		groupNode := &GroupNode{name: group.name}
+		for _, def := range group.ResourceDefs {
+			nodes, err := g.nodes(ctx, apiClient, def)
+			if err != nil {
+				return "", err
+			}
+			groupNode.children = append(groupNode.children, nodes...)
+		}
+		g.children = append(g.children, groupNode)
+	}
+	return tree.SprintHrn(g), nil
+}
+
+func (g *Graph) nodes(ctx *RequestContext, apiClient sacloud.APICaller, def ResourceDefinition) ([]tree.Node, error) {
+	resources, err := def.Compute(ctx, apiClient)
+	if err != nil {
+		return nil, err
+	}
+	var nodes []tree.Node
+	for _, r := range resources {
+		node := &GraphNode{resource: r}
+		for _, child := range def.Children() {
+			children, err := g.nodes(ctx, apiClient, child)
+			if err != nil {
+				return nil, err
+			}
+			node.children = append(node.children, children...)
+		}
+		nodes = append(nodes, node)
+	}
+	return nodes, nil
+}
+
+type GroupNode struct {
+	name     string
+	children []tree.Node
+}
+
+func (n *GroupNode) Data() interface{} {
+	return fmt.Sprintf("Group: %s", n.name)
+}
+
+func (n *GroupNode) Children() []tree.Node {
+	return n.children
+}
+
+type GraphNode struct {
+	resource Resource
+	children []tree.Node
+}
+
+func (n *GraphNode) Data() interface{} {
+	return n.resource.String()
+}
+
+func (n *GraphNode) Children() []tree.Node {
+	return n.children
+}

--- a/core/graph_test.go
+++ b/core/graph_test.go
@@ -1,0 +1,110 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"testing"
+
+	"github.com/sacloud/autoscaler/test"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
+
+func TestGraph_Tree(t *testing.T) {
+	ctx := testContext()
+	client := test.APIClient
+
+	type fields struct {
+		defGroups *ResourceDefGroups
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "basic",
+			fields: fields{
+				defGroups: &ResourceDefGroups{
+					groups: map[string]*ResourceDefGroup{
+						"web": {
+							name: "web",
+							ResourceDefs: ResourceDefinitions{
+								&stubResourceDef{
+									ResourceDefBase: &ResourceDefBase{
+										TypeName: "Stub",
+										children: ResourceDefinitions{
+											&stubResourceDef{
+												ResourceDefBase: &ResourceDefBase{
+													TypeName: "Stub",
+												},
+												computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources, error) {
+													return Resources{
+														&stubResource{
+															ResourceBase: &ResourceBase{
+																resourceType: ResourceTypeServer,
+															},
+															computeFunc: func(ctx *RequestContext, refresh bool) (Computed, error) {
+																return nil, nil
+															},
+														},
+													}, nil
+												},
+											},
+										},
+									},
+									computeFunc: func(ctx *RequestContext, apiClient sacloud.APICaller) (Resources, error) {
+										return Resources{
+											&stubResource{
+												ResourceBase: &ResourceBase{
+													resourceType: ResourceTypeDNS,
+												},
+												computeFunc: func(ctx *RequestContext, refresh bool) (Computed, error) {
+													return nil, nil
+												},
+											},
+										}, nil
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: `
+Sacloud AutoScaler
+└─ Group: web
+   └─ stub
+      └─ stub
+`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &Graph{
+				defGroups: tt.fields.defGroups,
+			}
+			got, err := g.Tree(ctx, client)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Tree() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if ("\n" + got) != tt.want {
+				t.Errorf("Tree() got = \n%v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/resource.go
+++ b/core/resource.go
@@ -34,6 +34,9 @@ type Resource interface {
 	Parent() Resource
 	// SetParent 親Resourceを設定
 	SetParent(parent Resource)
+
+	// String Resourceの文字列表現
+	String() string
 }
 
 // Resources Resourceのスライス

--- a/core/resource_dns.go
+++ b/core/resource_dns.go
@@ -42,6 +42,13 @@ func NewResourceDNS(ctx *RequestContext, apiClient sacloud.APICaller, def *Resou
 	return resource, nil
 }
 
+func (r *ResourceDNS) String() string {
+	if r == nil || r.dns == nil {
+		return "(empty)"
+	}
+	return fmt.Sprintf("{Type: %s, ID: %s, Name: %s}", r.Type(), r.dns.ID, r.dns.Name)
+}
+
 func (r *ResourceDNS) Compute(ctx *RequestContext, refresh bool) (Computed, error) {
 	if refresh {
 		if err := r.refresh(ctx); err != nil {

--- a/core/resource_elb.go
+++ b/core/resource_elb.go
@@ -42,6 +42,13 @@ func NewResourceELB(ctx *RequestContext, apiClient sacloud.APICaller, def *Resou
 	return resource, nil
 }
 
+func (r *ResourceELB) String() string {
+	if r == nil || r.elb == nil {
+		return "(empty)"
+	}
+	return fmt.Sprintf("{Type: %s, ID: %s, Name: %s}", r.Type(), r.elb.ID, r.elb.Name)
+}
+
 func (r *ResourceELB) Compute(ctx *RequestContext, refresh bool) (Computed, error) {
 	if refresh {
 		if err := r.refresh(ctx); err != nil {

--- a/core/resource_gslb.go
+++ b/core/resource_gslb.go
@@ -42,6 +42,13 @@ func NewResourceGSLB(ctx *RequestContext, apiClient sacloud.APICaller, def *Reso
 	return resource, nil
 }
 
+func (r *ResourceGSLB) String() string {
+	if r == nil || r.gslb == nil {
+		return "(empty)"
+	}
+	return fmt.Sprintf("{Type: %s, ID: %s, Name: %s}", r.Type(), r.gslb.ID, r.gslb.Name)
+}
+
 func (r *ResourceGSLB) Compute(ctx *RequestContext, refresh bool) (Computed, error) {
 	if refresh {
 		if err := r.refresh(ctx); err != nil {

--- a/core/resource_load_balancer.go
+++ b/core/resource_load_balancer.go
@@ -44,6 +44,13 @@ func NewResourceLoadBalancer(ctx *RequestContext, apiClient sacloud.APICaller, d
 	return resource, nil
 }
 
+func (r *ResourceLoadBalancer) String() string {
+	if r == nil || r.lb == nil {
+		return "(empty)"
+	}
+	return fmt.Sprintf("{Type: %s, Zone: %s, ID: %s, Name: %s}", r.Type(), r.zone, r.lb.ID, r.lb.Name)
+}
+
 func (r *ResourceLoadBalancer) Compute(ctx *RequestContext, refresh bool) (Computed, error) {
 	if refresh {
 		if err := r.refresh(ctx); err != nil {

--- a/core/resource_router.go
+++ b/core/resource_router.go
@@ -62,6 +62,13 @@ func NewResourceRouter(ctx *RequestContext, apiClient sacloud.APICaller, def *Re
 	return resource, nil
 }
 
+func (r *ResourceRouter) String() string {
+	if r == nil || r.router == nil {
+		return "(empty)"
+	}
+	return fmt.Sprintf("{Type: %s, Zone: %s, ID: %s, Name: %s}", r.Type(), r.zone, r.router.ID, r.router.Name)
+}
+
 func (r *ResourceRouter) Compute(ctx *RequestContext, refresh bool) (Computed, error) {
 	if refresh {
 		if err := r.refresh(ctx); err != nil {

--- a/core/resource_server.go
+++ b/core/resource_server.go
@@ -57,6 +57,13 @@ func NewResourceServer(ctx *RequestContext, apiClient sacloud.APICaller, def *Re
 	return resource, nil
 }
 
+func (r *ResourceServer) String() string {
+	if r == nil || r.server == nil {
+		return "(empty)"
+	}
+	return fmt.Sprintf("{Type: %s, Zone: %s, ID: %s, Name: %s}", r.Type(), r.zone, r.server.ID, r.server.Name)
+}
+
 func (r *ResourceServer) Compute(ctx *RequestContext, refresh bool) (Computed, error) {
 	if refresh {
 		if err := r.refresh(ctx); err != nil {

--- a/core/resource_stub_test.go
+++ b/core/resource_stub_test.go
@@ -41,6 +41,10 @@ type stubResource struct {
 	computeFunc func(ctx *RequestContext, refresh bool) (Computed, error)
 }
 
+func (r *stubResource) String() string {
+	return "stub"
+}
+
 func (r *stubResource) Compute(ctx *RequestContext, refresh bool) (Computed, error) {
 	if r.computeFunc != nil {
 		return r.computeFunc(ctx, refresh)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/goccy/go-yaml v1.8.9
 	github.com/hashicorp/go-multierror v1.0.1-0.20190722213833-bdca7bb83f60
 	github.com/sacloud/libsacloud/v2 v2.19.1
+	github.com/shivamMg/ppds v0.0.1
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20210304124612-50617c2ba197 // indirect

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/sacloud/ftps v1.1.0/go.mod h1:h4awhOi3PEyhKLj1FpXjoVV5yVkmRUU+d5L95Ew
 github.com/sacloud/libsacloud/v2 v2.19.1 h1:BDbIFC6FRw3NN1l3ASZM3GUNXehyauAINFB5PstgXjo=
 github.com/sacloud/libsacloud/v2 v2.19.1/go.mod h1:EPYsXh1SxP10pD6J7a0nK67gd03wAq413TSfCfl5sjc=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/shivamMg/ppds v0.0.1 h1:idK2dpaen652zOO+OmcwmyoPNncBNqfHjF/14eS5JIk=
+github.com/shivamMg/ppds v0.0.1/go.mod h1:hb39VqUO6qfkb9zBBQPTIV1vWBtI7yQsG0wr3pN78fM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=


### PR DESCRIPTION
closes #150 

現在のコンフィギュレーションを読み込み、操作対象リソースを一覧表示するためのサブコマンド`core resources`を追加する。
オートスケール実行時には対象が異なるケース(リソースが追加/更新/削除された、など)があり得るため、コンフィギュレーションの確認のためだけに利用することを想定している。

```bash
# 実行例
$ autoscaler core resources

Sacloud AutoScaler
└─ Group: web
   ├─ {Type: Server, Zone: is1a, ID: 100000000000, Name: example-01}
   ├─ {Type: Server, Zone: is1b, ID: 200000000000, Name: example-02}
   └─ {Type: Server, Zone: tk1b, ID: 300000000000, Name: example-03}

```

### 実装

coreにてリソース定義(ResourceDefGroups)からグラフを形成、https://github.com/shivamMg/ppds を用いてツリー表示を行う。
