### PR TITLE
Added ExecStartPost for running chmod command

### DIFF
--- a/examples/systemd/autoscaler_core.service
+++ b/examples/systemd/autoscaler_core.service
@@ -5,6 +5,8 @@ Description=SakuraCloud AutoScaler Core Server
 User=autoscaler
 EnvironmentFile=/etc/autoscaler/core.config
 ExecStart=/usr/local/sbin/autoscaler server start $OPTIONS
+# NginxなどでUNIX domain socketをプロキシしたい場合にコメントを解除する
+#ExecStartPost=/bin/bash -c "while [ ! -e /var/run/autoscaler/autoscaler.sock ]; do sleep 1; done; /usr/bin/chmod 0660 /var/run/autoscaler/autoscaler.sock"
 Restart=always
 
 [Install]


### PR DESCRIPTION
systemdのユニットファイルにExecStartPostを追加する。

Nginxなどでhttps->UNIX domain socketへプロキシする場合、ソケットの読み書きができる必要がある。
このためにソケットファイル作成後にchmodするスクリプトの例をユニットファイル内に追加する。
デフォルトではコメントアウトされており、必要な場合だけコメント解除して利用する。