### PR TITLE
Remove source/action field from request/job ID

### DIFF
--- a/core/request.go
+++ b/core/request.go
@@ -47,9 +47,9 @@ func (r *requestInfo) String() string {
 	return fmt.Sprintf("%#v", r)
 }
 
-// ID リクエストのSource/Action/ResourceGroupNameの組み合わせで一意に決まるID
+// ID リクエストのパラメータから一意に決まるID
 //
-// RequestTypesのUp/Downの違いやDesiredStateNameの違いを問わずに値を決めるため、同一リソースに対する同一アクションが実行中かの判定に利用できる
+// RequestTypesのUp/Downの違いやDesiredStateNameの違いを問わずに値を決めるため、同一リソースに対するアクションが実行中かの判定に利用できる
 func (r *requestInfo) ID() string {
-	return fmt.Sprintf("%s-%s-%s", r.source, r.action, r.resourceGroupName)
+	return r.resourceGroupName
 }

--- a/core/request_context.go
+++ b/core/request_context.go
@@ -31,7 +31,7 @@ type RequestContext struct {
 
 // NewRequestContext 新しいリクエストコンテキストを生成する
 func NewRequestContext(parent context.Context, request *requestInfo, logger *log.Logger) *RequestContext {
-	logger = logger.With("request-type", request.requestType, "scaling-job-id", request.ID())
+	logger = logger.With("request-type", request.requestType, "source", request.source, "group", request.resourceGroupName, "action", request.action)
 	return &RequestContext{
 		ctx:     parent,
 		request: request,


### PR DESCRIPTION
closes #134 

Job IDからSource/Actionフィールドを除去する。
これによりResourceGroupNameが同一であれば同一ジョブとみなされ同時実行制御が行われるようになる。

例:

```bash
# すべて同一ジョブなため冷却期間中は2番目以降のコマンドは実行されない
$ autoscaler inputs direct up
$ autoscaler inputs direct down
$ autoscaler inputs direct up --source foobar
```