### PR TITLE
Unmarshal YAML strictly

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -65,7 +65,7 @@ func (c *Config) load(reader io.Reader) error {
 	if err != nil {
 		return fmt.Errorf("loading configuration failed: %s", err)
 	}
-	if err := yaml.Unmarshal(data, c); err != nil {
+	if err := yaml.UnmarshalWithOptions(data, c, yaml.Strict()); err != nil {
 		return fmt.Errorf("unmarshalling of config values failed: %s", err)
 	}
 

--- a/core/resource_def_group_marshal.go
+++ b/core/resource_def_group_marshal.go
@@ -22,7 +22,7 @@ import (
 
 func (rdg *ResourceDefGroup) UnmarshalYAML(data []byte) error {
 	var rawMap map[string]interface{}
-	if err := yaml.Unmarshal(data, &rawMap); err != nil {
+	if err := yaml.UnmarshalWithOptions(data, &rawMap, yaml.Strict()); err != nil {
 		return err
 	}
 
@@ -86,11 +86,6 @@ func (rdg *ResourceDefGroup) unmarshalResourceDefFromMap(data map[string]interfa
 		return nil, fmt.Errorf("'type' is not string: %v", data)
 	}
 
-	remarshelded, err := yaml.Marshal(data)
-	if err != nil {
-		return nil, fmt.Errorf("yaml.Marshal failed with %v", data)
-	}
-
 	var defs ResourceDefinitions
 	if rawChildren, ok := data["resources"]; ok {
 		if children, ok := rawChildren.([]interface{}); ok {
@@ -104,27 +99,33 @@ func (rdg *ResourceDefGroup) unmarshalResourceDefFromMap(data map[string]interfa
 				}
 			}
 		}
+		delete(data, "resources")
+	}
+
+	remarshelded, err := yaml.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("yaml.Marshal failed with %v", data)
 	}
 
 	var def ResourceDefinition
 	switch typeName {
 	case "Server":
 		v := &ResourceDefServer{}
-		if err := yaml.Unmarshal(remarshelded, v); err != nil {
+		if err := yaml.UnmarshalWithOptions(remarshelded, v, yaml.Strict()); err != nil {
 			return nil, fmt.Errorf("yaml.Unmarshal failed with %v", data)
 		}
 		v.children = defs
 		def = v
 	case "ServerGroup":
 		v := &ResourceDefServerGroup{}
-		if err := yaml.Unmarshal(remarshelded, v); err != nil {
+		if err := yaml.UnmarshalWithOptions(remarshelded, v, yaml.Strict()); err != nil {
 			return nil, fmt.Errorf("yaml.Unmarshal failed with %v", data)
 		}
 		v.children = defs
 		def = v
 	case "EnhancedLoadBalancer", "ELB":
 		v := &ResourceDefELB{}
-		if err := yaml.Unmarshal(remarshelded, v); err != nil {
+		if err := yaml.UnmarshalWithOptions(remarshelded, v, yaml.Strict()); err != nil {
 			return nil, fmt.Errorf("yaml.Unmarshal failed with %v", data)
 		}
 		// TypeNameのエイリアスを正規化
@@ -133,28 +134,28 @@ func (rdg *ResourceDefGroup) unmarshalResourceDefFromMap(data map[string]interfa
 		def = v
 	case "GSLB":
 		v := &ResourceDefGSLB{}
-		if err := yaml.Unmarshal(remarshelded, v); err != nil {
+		if err := yaml.UnmarshalWithOptions(remarshelded, v, yaml.Strict()); err != nil {
 			return nil, fmt.Errorf("yaml.Unmarshal failed with %v", data)
 		}
 		v.children = defs
 		def = v
 	case "DNS":
 		v := &ResourceDefDNS{}
-		if err := yaml.Unmarshal(remarshelded, v); err != nil {
+		if err := yaml.UnmarshalWithOptions(remarshelded, v, yaml.Strict()); err != nil {
 			return nil, fmt.Errorf("yaml.Unmarshal failed with %v", data)
 		}
 		v.children = defs
 		def = v
 	case "Router":
 		v := &ResourceDefRouter{}
-		if err := yaml.Unmarshal(remarshelded, v); err != nil {
+		if err := yaml.UnmarshalWithOptions(remarshelded, v, yaml.Strict()); err != nil {
 			return nil, fmt.Errorf("yaml.Unmarshal failed with %v", data)
 		}
 		v.children = defs
 		def = v
 	case "LoadBalancer", "LB":
 		v := &ResourceDefLoadBalancer{}
-		if err := yaml.Unmarshal(remarshelded, v); err != nil {
+		if err := yaml.UnmarshalWithOptions(remarshelded, v, yaml.Strict()); err != nil {
 			return nil, fmt.Errorf("yaml.Unmarshal failed with %v", data)
 		}
 		// TypeNameのエイリアスを正規化

--- a/core/resource_def_groups.go
+++ b/core/resource_def_groups.go
@@ -57,7 +57,7 @@ func (rg *ResourceDefGroups) Set(key string, group *ResourceDefGroup) {
 
 func (rg *ResourceDefGroups) UnmarshalYAML(data []byte) error {
 	var loaded map[string]*ResourceDefGroup
-	if err := yaml.Unmarshal(data, &loaded); err != nil {
+	if err := yaml.UnmarshalWithOptions(data, &loaded, yaml.Strict()); err != nil {
 		return err
 	}
 	for k, v := range loaded {

--- a/core/resource_def_groups_test.go
+++ b/core/resource_def_groups_test.go
@@ -32,6 +32,22 @@ func TestResourceDefGroups_UnmarshalYAML(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name: "unknown key",
+			r:    &ResourceDefGroups{},
+			args: args{
+				data: []byte(`
+web: 
+  resources:
+    - type: Server
+      selector:
+        names: ["test-name"]
+        zones: ["is1a"]
+      unknown_key: "foobar"
+`),
+			},
+			wantErr: true,
+		},
+		{
 			name: "resource group",
 			r: func() *ResourceDefGroups {
 				rgs := newResourceDefGroups()
@@ -132,7 +148,7 @@ web:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var target ResourceDefGroups
-			if err := yaml.Unmarshal(tt.args.data, &target); (err != nil) != tt.wantErr {
+			if err := yaml.UnmarshalWithOptions(tt.args.data, &target, yaml.Strict()); (err != nil) != tt.wantErr {
 				t.Errorf("UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			require.EqualValues(t, tt.r, &target)


### PR DESCRIPTION
`yaml.UnmarshalWithOptions()`で`yaml.Strict()`を指定することでYAMLのアンマーシャルを厳密に行う。