### PR TITLE
Support named plans for ServerGroup

### DIFF
--- a/commands/core/example/example.yaml
+++ b/commands/core/example/example.yaml
@@ -47,6 +47,20 @@ resources:
         min_size: 5   # 最小インスタンス数
         max_size: 20  # 最大インスタンス数
 
+        # プラン一覧(省略可能)
+        # Inputsからdesired state nameが指定された場合に利用する名前付きプランを定義する
+        # desired state nameが指定されなかった場合はmin_sizeからmax_sizeの間でスケールアウト or インする
+        # 例: 現在10台存在する場合:
+        #     - UpかつDesiredStateName == "largest"の場合 -> 10台追加
+        #     - UpかつDesiredStateName == "" or "default"の場合 -> 1台追加
+        plans:
+          - name: smallest
+            size: 5
+          - name: middle
+            size: 10
+          - name: largest
+            size: 20
+
         template: # 各サーバのテンプレート
           tags: [ "tag1", "tag2" ]
           description: "..."

--- a/commands/core/example/example.yaml
+++ b/commands/core/example/example.yaml
@@ -56,7 +56,7 @@ resources:
         plans:
           - name: smallest
             size: 5
-          - name: middle
+          - name: medium
             size: 10
           - name: largest
             size: 20

--- a/core/plan_server_group.go
+++ b/core/plan_server_group.go
@@ -1,0 +1,46 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+type ServerGroupPlan struct {
+	Name string `yaml:"name"`
+	Size int    `yaml:"size"`
+}
+
+func (p *ServerGroupPlan) PlanName() string {
+	return p.Name
+}
+func (p *ServerGroupPlan) Equals(resource interface{}) bool {
+	size, ok := resource.(int)
+	if !ok {
+		return false
+	}
+	return size == p.Size
+}
+func (p *ServerGroupPlan) LessThan(resource interface{}) bool {
+	size, ok := resource.(int)
+	if !ok {
+		return false
+	}
+	return p.Size < size
+}
+
+func (p *ServerGroupPlan) LessThanPlan(plan ResourcePlan) bool {
+	sgPlan, ok := plan.(*ServerGroupPlan)
+	if !ok {
+		return false
+	}
+	return p.Size < sgPlan.Size
+}

--- a/core/resource_def_server_group_test.go
+++ b/core/resource_def_server_group_test.go
@@ -354,7 +354,7 @@ func TestResourceDefServerGroup_Compute(t *testing.T) {
 				MinSize: 1,
 				MaxSize: 5,
 				Plans: []*ServerGroupPlan{
-					{Size: 3, Name: "middle"},
+					{Size: 3, Name: "medium"},
 					{Size: 5, Name: "largest"},
 				},
 				Template: &ServerGroupInstanceTemplate{
@@ -370,7 +370,7 @@ func TestResourceDefServerGroup_Compute(t *testing.T) {
 					source:            "default",
 					action:            "default",
 					resourceGroupName: "default",
-					desiredStateName:  "middle",
+					desiredStateName:  "medium",
 				}, nil, test.Logger),
 			},
 			want:    nil,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -349,6 +349,12 @@ zone: <"is1a" | "is1b" | "tk1a" | "tk1b" | "tk1v">
 min_size: <number>
 max_size: <number>
 
+# 名前付きプラン(サーバグループの場合はサーバ数をプランとして表す)
+plans:
+  [ - name: <string> # プラン名、省略可能 
+      size: <number> # サーバ数
+  ]
+
 # 強制シャットダウンを行うか(ACPIが利用できないサーバの場合trueにする)
 shutdown_force: <boolean>
 
@@ -410,6 +416,8 @@ template:
 resources:
   [ - <resource_definition> ]
 ```
+
+`plans`を省略した場合、`size`に`min_size`から`max_size`までの値を持つプランが存在するとみなします。
 
 #### <resource_selector>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -482,7 +482,7 @@ plans:
     memory: 8
   - core: 4
     memory: 16
-    name: "middle"
+    name: "medium"
   - core: 8
     memory: 16
   - core: 10


### PR DESCRIPTION
ServerGroupで名前付きプランをサポートする。

```yaml
resources:
  web:
      # サーバ(水平スケール)
      - type: ServerGroup
        name: "server-group"
        zone: "is1a"

        min_size: 5   # 最小インスタンス数
        max_size: 20  # 最大インスタンス数

        plans:
          - name: smallest
            size: 5
          - name: medium
            size: 10
          - name: largest
            size: 20
```

これにより、InputsからDesiredStateNameを指定することで希望するサーバ数へスケールアウト/インできる。

例:
```bash
# サーバ数をlargestプラン(20台)まで一気に増やす
$ autoscaler inputs direct up --desired-state-name largest

# サーバ数をsmallestプラン(5台)まで一気に減らす
$ autoscaler inputs direct down --desired-state-name smallest
```