### PR TITLE
Add metadata to expose to upstream

### DIFF
--- a/commands/core/example/example.yaml
+++ b/commands/core/example/example.yaml
@@ -85,6 +85,27 @@ resources:
               assign_netmask_len: 24                # NICに割り当てるサブネットマスク長
               default_route: "192.168.12.1"
 
+              # 上流リソースに渡すためのメタデータ
+              expose:
+                ports: [ 80, 443 ] # このNICで上流リソースに公開するポート番号
+
+                # ELB向け
+                server_group_name: "group1"
+
+                ## GSLB向け
+                #weight: 1
+
+                ## LB向け
+                #vips: [ "192.168.11.1" ] # 省略可
+                #health_check:
+                #  protocol: http
+                #  path: "/healthz"
+                #  status_code: 200
+
+                ## DNS向け
+                #record_name: "www"
+                #record_ttl: 10
+
           # ディスク
           disks:
             - name_prefix: "..." # 省略した場合は 'サーバ名+ディスク連番' (例: server-group-001-001)

--- a/core/computed_elb.go
+++ b/core/computed_elb.go
@@ -42,7 +42,7 @@ func (c *computedELB) Name() string {
 }
 
 func (c *computedELB) Type() ResourceTypes {
-	return ResourceTypeEnhancedLoadBalancer
+	return ResourceTypeELB
 }
 
 func (c *computedELB) Zone() string {

--- a/core/resource_definition.go
+++ b/core/resource_definition.go
@@ -58,14 +58,17 @@ func (r *ResourceDefBase) Type() ResourceTypes {
 		return ResourceTypeServerGroup
 	case ResourceTypeServerGroupInstance.String():
 		return ResourceTypeServerGroupInstance
-	case ResourceTypeEnhancedLoadBalancer.String(), "ELB":
-		return ResourceTypeEnhancedLoadBalancer
+	case ResourceTypeELB.String(), "ELB":
+		return ResourceTypeELB
 	case ResourceTypeGSLB.String():
 		return ResourceTypeGSLB
 	case ResourceTypeDNS.String():
 		return ResourceTypeDNS
+	case ResourceTypeLoadBalancer.String():
+		return ResourceTypeLoadBalancer
 	}
-	return ResourceTypeUnknown
+
+	return ResourceTypeLoadBalancer
 }
 
 // Children 子リソースを返す(自身は含まない)

--- a/core/resource_elb.go
+++ b/core/resource_elb.go
@@ -31,7 +31,7 @@ type ResourceELB struct {
 
 func NewResourceELB(ctx *RequestContext, apiClient sacloud.APICaller, def *ResourceDefELB, elb *sacloud.ProxyLB) (*ResourceELB, error) {
 	resource := &ResourceELB{
-		ResourceBase: &ResourceBase{resourceType: ResourceTypeEnhancedLoadBalancer},
+		ResourceBase: &ResourceBase{resourceType: ResourceTypeELB},
 		apiClient:    apiClient,
 		elb:          elb,
 		def:          def,

--- a/core/resource_types.go
+++ b/core/resource_types.go
@@ -21,7 +21,7 @@ const (
 	ResourceTypeServer
 	ResourceTypeServerGroup
 	ResourceTypeServerGroupInstance
-	ResourceTypeEnhancedLoadBalancer
+	ResourceTypeELB
 	ResourceTypeGSLB
 	ResourceTypeDNS
 	ResourceTypeRouter
@@ -36,7 +36,7 @@ func (rt ResourceTypes) String() string {
 		return "ServerGroup"
 	case ResourceTypeServerGroupInstance:
 		return "ServerGroupInstance"
-	case ResourceTypeEnhancedLoadBalancer:
+	case ResourceTypeELB:
 		return "EnhancedLoadBalancer"
 	case ResourceTypeGSLB:
 		return "GSLB"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -411,6 +411,37 @@ template:
     assign_netmask_len: <int>
     default_route: <string>
     packet_filter_id: <string>
+    
+    # 上流リソースの操作のためのメタデータ
+    # サーバグループの上流にELB/GSLB/LB/DNSを定義している場合のみ指定可能
+    expose:
+      # 公開するポート番号のリスト
+      ports: [ - <number> ] 
+      
+      # ELB向け: 実サーバ登録時のサーバグループ名
+      server_group_name: <string>
+
+      # GSLB向け: 実サーバ登録時の重み値
+      weight: <number>
+
+      # LB向け: 対象VIPのリスト
+      # 省略した場合、このNICと同じネットワーク内に存在するVIP全てが対象となる
+      vips: [ - <string> ]
+      
+      # LB向け: 実サーバ登録時のヘルスチェック
+      health_check:
+        # ヘルスチェックで用いるプロトコル
+        protocol: < "http" | "https" | "ping" | "tcp" >
+        
+        # プロトコルがhttp/httpsの場合のリクエスト先パス 例:/index.html
+        path: <string>
+        # プロトコルがhttp/httpsの場合の期待するレスポンスステータスコード
+        status_code: <number>
+
+      # DNS向け: レコード登録時のレコード名 例:www
+      record_name: <string>
+      # DNS向け: レコード登録時のTTL
+      record_ttl: <number>
 
 # 子リソースの定義(省略可能)
 resources:


### PR DESCRIPTION
水平スケール時に上流リソースの設定を行うためにIPアドレス/ポート番号の組み合わせなどについてのメタデータを追加する。

## 背景

水平スケール時にELBやGSLBといった上流リソースの設定を行いたいが、設定の際はサーバのどのIPアドレス/ポートを利用するかといった情報が必要になる。

### 必要な情報

ELB:
  - IPアドレス
  - ポート番号
  - サーバグループ名

GSLB:
  - IPアドレス
  - 重み値

LB:
  - VIPとポート番号の組み合わせ
  - IPアドレス
  - 監視方法(http/httpsの場合は以下も必要)
    - リクエストパス
    - レスポンスコード

DNS: (Aレコードを登録する想定)
  - レコード名
  - IPアドレス
  - TTL

これらの情報をハンドラーに伝えるために、サーバグループのテンプレート内でメタデータとして指定可能にする。

イメージ:

```yaml
      - type: ServerGroup
        template:
          # NICs
          network_interfaces:
            - upstream: "shared"
              # 上流リソースに渡すためのメタデータ
              expose:
                ports: [80,443] # ポート番号

                # ELB向け
                server_group_name: ""

                # GSLB向け
                weight: 1 

                # LB向け
                vips: ["192.168.11.1"] # 省略可
                health_check: 
                  protocol: http
                  path: "/healthz"
                  status_code: 200

                # DNS向け
                record_name: "www"
                record_ttl: 10
```

項目が少ないため、各上流リソース向けに必要な情報を個別のフィールドにするのではなくexpose配下にunionした形とした。