### PR TITLE
Add/delete servers on LB when horizontal scaling

### DIFF
--- a/core/server_group_instance_template.go
+++ b/core/server_group_instance_template.go
@@ -417,6 +417,9 @@ func (m *ServerGroupNICMetadata) Validate(parent ResourceDefinition, nicIndex in
 				errors = multierror.Append(errors, fmt.Errorf(format, "record_ttl", ResourceTypeGSLB))
 			}
 		case ResourceTypeLoadBalancer:
+			if len(m.Ports) == 0 {
+				errors = multierror.Append(errors, fmt.Errorf(requiredFormat, "ports", ResourceTypeLoadBalancer))
+			}
 			if m.HealthCheck == nil {
 				errors = multierror.Append(errors, fmt.Errorf(requiredFormat, "health_check", ResourceTypeLoadBalancer))
 			}

--- a/core/server_group_instance_template_test.go
+++ b/core/server_group_instance_template_test.go
@@ -528,6 +528,7 @@ func TestServerGroupNICMetadata_Validate(t *testing.T) {
 				nicIndex: 0,
 			},
 			want: []error{
+				fmt.Errorf("ports: required when parent is LoadBalancer"),
 				fmt.Errorf("health_check: required when parent is LoadBalancer"),
 			},
 		},
@@ -601,7 +602,8 @@ func TestServerGroupNICMetadata_Validate(t *testing.T) {
 		{
 			name: "with invalid health_check",
 			expose: &ServerGroupNICMetadata{
-				VIPs: []string{"192.168.0.1"},
+				Ports: []int{80},
+				VIPs:  []string{"192.168.0.1"},
 				HealthCheck: &ServerGroupNICMetadataHealthCheck{
 					Protocol:   "ping",
 					Path:       "/healthz",

--- a/handler/customize.go
+++ b/handler/customize.go
@@ -1,0 +1,28 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+func (x *ServerGroupInstance_NIC) EachIPAndExposedPort(fn func(ip string, port int) error) error {
+	if x == nil || x.ExposeInfo == nil || x.AssignedNetwork == nil {
+		return nil
+	}
+
+	for _, port := range x.ExposeInfo.Ports {
+		if err := fn(x.AssignedNetwork.IpAddress, int(port)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/handlers/lb/servers_handler_test.go
+++ b/handlers/lb/servers_handler_test.go
@@ -1,0 +1,109 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lb
+
+import (
+	"testing"
+
+	"github.com/sacloud/autoscaler/handler"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServersHandler_filteredVIPs(t *testing.T) {
+	type args struct {
+		vips       sacloud.LoadBalancerVirtualIPAddresses
+		exposeInfo *handler.ServerGroupInstance_ExposeInfo
+	}
+	tests := []struct {
+		name string
+		args args
+		want sacloud.LoadBalancerVirtualIPAddresses
+	}{
+		{
+			name: "without vips",
+			args: args{
+				vips: sacloud.LoadBalancerVirtualIPAddresses{
+					{
+						VirtualIPAddress: "192.168.0.1",
+						Port:             80,
+					},
+					{
+						VirtualIPAddress: "192.168.0.1",
+						Port:             443,
+					},
+					{
+						VirtualIPAddress: "192.168.0.2",
+						Port:             8080,
+					},
+				},
+				exposeInfo: &handler.ServerGroupInstance_ExposeInfo{},
+			},
+			want: sacloud.LoadBalancerVirtualIPAddresses{
+				{
+					VirtualIPAddress: "192.168.0.1",
+					Port:             80,
+				},
+				{
+					VirtualIPAddress: "192.168.0.1",
+					Port:             443,
+				},
+				{
+					VirtualIPAddress: "192.168.0.2",
+					Port:             8080,
+				},
+			},
+		},
+		{
+			name: "with vips",
+			args: args{
+				vips: sacloud.LoadBalancerVirtualIPAddresses{
+					{
+						VirtualIPAddress: "192.168.0.1",
+						Port:             80,
+					},
+					{
+						VirtualIPAddress: "192.168.0.1",
+						Port:             443,
+					},
+					{
+						VirtualIPAddress: "192.168.0.2",
+						Port:             8080,
+					},
+				},
+				exposeInfo: &handler.ServerGroupInstance_ExposeInfo{
+					Vips: []string{"192.168.0.1"},
+				},
+			},
+			want: sacloud.LoadBalancerVirtualIPAddresses{
+				{
+					VirtualIPAddress: "192.168.0.1",
+					Port:             80,
+				},
+				{
+					VirtualIPAddress: "192.168.0.1",
+					Port:             443,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &ServersHandler{}
+			got := h.filteredVIPs(tt.args.vips, tt.args.exposeInfo)
+			require.EqualValues(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
#188 の後続PR, #191 のLB版

サーバの水平スケール時にロードバランサに実サーバとして登録/削除を行う。

```yaml
resources:
  - type: LoadBalancer
    selector:
      names: ["example"]
      zones: ["is1a"]
    resources:
    # オートスケーリンググループ
    - type: ServerGroup
      # ...略...
      template:
        # NICs
        network_interfaces:
          - upstream: shared
          - upstream:
              names: ["autoscaler-test01"]
            assign_cidr_block: "192.168.0.16/28"
            assign_netmask_len: 24
            default_route: "192.168.0.1"

            expose:
              ports: [ 80, 443] # このNICで上流リソースに公開するポート番号

              # vips: [ "192.168.11.1" ] # 省略可
              health_check:
                protocol: ping
                # path: "/healthz"
                # status_code: 200
```

- network_interfacesの各要素ごとに処理
- network_interfacesの各要素で`expose`と`expose.ports`が指定されていたら処理対象とする

この例だと以下がLBに登録される
- 1台目のサーバ
  - 192.168.0.17:80
  - 192.168.0.17:443
- 2台目のサーバ
  - 192.168.0.18:80
  - 192.168.0.18:443

- expose.vipsが指定されていたらLBの一致するVIPのみが処理対象となる