### PR TITLE
Implement exception handling when there is only one plan

### DIFF
--- a/core/resource_def_server_group.go
+++ b/core/resource_def_server_group.go
@@ -160,7 +160,7 @@ func (d *ResourceDefServerGroup) desiredPlan(ctx *RequestContext, currentCount i
 		}
 		return nil, fmt.Errorf("invalid plan: %#v", plan)
 	}
-	return &ServerGroupPlan{Size: currentCount + 1}, nil
+	return &ServerGroupPlan{Size: currentCount}, nil
 }
 
 func (d *ResourceDefServerGroup) resourceIndex(resource Resource) int {

--- a/core/resource_plans.go
+++ b/core/resource_plans.go
@@ -49,8 +49,17 @@ func (p *ResourcePlans) Sort() {
 //
 // 該当プランが存在しない場合はnilを返す
 func (p *ResourcePlans) Next(resource interface{}) ResourcePlan {
+	plans := *p
+	if len(plans) == 1 {
+		plan := plans[0]
+		if plan.Equals(resource) || !plan.LessThan(resource) {
+			return plan
+		}
+		return nil
+	}
+
 	next := false
-	for _, plan := range *p {
+	for _, plan := range plans {
 		if plan.Equals(resource) || plan.LessThan(resource) {
 			next = true
 			continue
@@ -67,6 +76,14 @@ func (p *ResourcePlans) Next(resource interface{}) ResourcePlan {
 // 該当プランが存在しない場合はnilを返す
 func (p *ResourcePlans) Prev(resource interface{}) ResourcePlan {
 	plans := *p
+	if len(plans) == 1 {
+		plan := plans[0]
+		if plan.Equals(resource) || plan.LessThan(resource) {
+			return plan
+		}
+		return nil
+	}
+
 	var prev ResourcePlan
 	for i, plan := range plans {
 		if i > 0 && (plan.Equals(resource) || !plan.LessThan(resource)) {

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -28,3 +28,12 @@ func testContext() *RequestContext {
 		resourceGroupName: "web",
 	}, nil, test.Logger)
 }
+
+func testContextDown() *RequestContext {
+	return NewRequestContext(context.Background(), &requestInfo{
+		requestType:       requestTypeDown,
+		source:            "default",
+		action:            "default",
+		resourceGroupName: "web",
+	}, nil, test.Logger)
+}


### PR DESCRIPTION
fixes #196 

Next/Prevプラン取得処理においてプランが1つだけの場合の例外処理を追加する。

### 詳細

通常、以下のようにした場合、min_size〜max_size分のプランが作成される。

```
- type: "ServerGroup"
  max_size: 0
  min_size: 2
```

```
# 上記の定義から作成されるプラン一覧
- {size:0}
- {size:1}
- {size:2}
```

このプラン一覧+現在の状態+Up or Downを元にプラン算出が行われる。

- 現在:0, Up -> {size:1}
- 現在:1, UP -> {size:2}
- 現在:0, Down -> nil
- 現在:1, Down -> {size:1}

しかし、以下のようなリソース定義の場合、プランが1つだけになり得る。

```
- type: "ServerGroup"
  max_size: 1
  min_size: 1
```

この場合にNext/Prevがうまくプランを決定できなかった。このPRではこの問題を修正している。
