### PR TITLE
Introduce clang-format to fomart .proto

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+---
+Language: Proto
+BasedOnStyle: Google
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ clean:
 
 .PHONY: tools
 tools:
+	echo "[INFO] please install clang-format manually if you would like to edit .proto"
 	(cd tools; go install golang.org/x/tools/cmd/goimports)
 	(cd tools; go install golang.org/x/tools/cmd/stringer)
 	(cd tools; go install github.com/sacloud/addlicense)
@@ -92,6 +93,10 @@ goimports:
 .PHONY: fmt
 fmt:
 	find . -name '*.go' | grep -v vendor | xargs gofmt -s -w
+
+.PHONY: fmt-proto
+fmt-proto:
+	find $(CURDIR)/protos/ -name "*.proto" | xargs clang-format -i
 
 .PHONY: build-textlint
 build-textlint:

--- a/protos/handler.proto
+++ b/protos/handler.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+syntax            = "proto3";
 option go_package = "github.com/sacloud/autoscaler/handler";
 
 package autoscaler;
@@ -8,7 +8,8 @@ package autoscaler;
 // sacloud/autoscalerのHandlersがサービスを公開し、Coreがクライアントとして実装する
 // 一連のrpcは操作対象のリソースごとに順次呼ばれる
 //
-// 例: 親リソース(リソース1)+子リソース(リソース2)を操作する場合以下の順で呼ばれる
+// 例:
+// 親リソース(リソース1)+子リソース(リソース2)を操作する場合以下の順で呼ばれる
 //
 //   - リソース2: PreHandle
 //   - リソース2: Handle
@@ -33,13 +34,13 @@ message HandleRequest {
   string resource_name = 2;
 
   // スケールジョブのID
-  string scaling_job_id            = 3;
+  string scaling_job_id = 3;
 
   // ハンドラーへの指示
   ResourceInstructions instruction = 4;
 
   // リソースのあるべき姿
-  Resource desired                 = 5;
+  Resource desired = 5;
 }
 
 // PostHandle時のリクエストパラメータ
@@ -58,13 +59,13 @@ message PostHandleRequest {
   string resource_name = 2;
 
   // スケールジョブのID
-  string scaling_job_id        = 3;
+  string scaling_job_id = 3;
 
   // Handleの結果
   ResourceHandleResults result = 4;
 
   // Handleの結果を反映した、リソースの現在の状態
-  Resource current             = 5;
+  Resource current = 5;
 }
 
 // Handlersからのストリームレスポンス
@@ -73,7 +74,6 @@ message HandleResponse {
     reserved 1 to 10;
 
     UNKNOWN  = 0;
-
     RECEIVED = 11;
     ACCEPTED = 12;
     RUNNING  = 13;
@@ -85,7 +85,7 @@ message HandleResponse {
 
   string scaling_job_id = 1;
   Status status         = 2;
-  string log            = 3; // Handlersが出力する追加的なメッセージ
+  string log = 3;  // Handlersが出力する追加的なメッセージ
 }
 
 // Handlersが対象リソースをどう扱うべきかを示す
@@ -94,103 +94,103 @@ enum ResourceInstructions {
   CREATE  = 1;
   UPDATE  = 2;
   DELETE  = 3;
-  NOOP    = 4; // 特に変更の必要がない状態、参照用のリソースなどで利用される
+  NOOP    = 4;  // 特に変更の必要がない状態、参照用のリソースなどで利用される
 }
 
 // 汎用リソース型
 message Resource {
   oneof resource {
-    Server server                              = 1;
-    ServerGroupInstance server_group_instance  = 2;
-    ELB elb                                    = 3;
-    GSLB gslb                                  = 4;
-    DNS dns                                    = 5;
-    Router router                              = 6;
-    LoadBalancer load_balancer                 = 7;
+    Server              server                = 1;
+    ServerGroupInstance server_group_instance = 2;
+    ELB                 elb                   = 3;
+    GSLB                gslb                  = 4;
+    DNS                 dns                   = 5;
+    Router              router                = 6;
+    LoadBalancer        load_balancer         = 7;
   }
 }
 
 message Server {
-  Parent parent                         = 1;
+  Parent parent = 1;
   reserved 2 to 10;
 
-  string id                             = 11;
-  string zone                           = 12;
-  uint32 core                           = 13;
-  uint32 memory                         = 14;
-  bool dedicated_cpu                    = 15;
+  string               id               = 11;
+  string               zone             = 12;
+  uint32               core             = 13;
+  uint32               memory           = 14;
+  bool                 dedicated_cpu    = 15;
   repeated NetworkInfo assigned_network = 16;
-  string name                           = 17;
-  bool shutdown_force                   = 18;
+  string               name             = 17;
+  bool                 shutdown_force   = 18;
 }
 
 message ServerGroupInstance {
-  Parent parent                   = 1;
+  Parent parent = 1;
   reserved 2 to 10;
 
-  string id                       = 11; // 新規作成指示時は空
-  string zone                     = 12;
+  string id   = 11;  // 新規作成指示時は空
+  string zone = 12;
 
   // plan
-  uint32 core                     = 13;
-  uint32 memory                   = 14;
-  bool dedicated_cpu              = 15;
-  string private_host_id          = 16;
+  uint32 core            = 13;
+  uint32 memory          = 14;
+  bool   dedicated_cpu   = 15;
+  string private_host_id = 16;
 
   // disks
-  repeated Disk disks             = 17;
-  EditParameter edit_parameter    = 18; // 1番目のディスクにのみ有効
+  repeated Disk disks          = 17;
+  EditParameter edit_parameter = 18;  // 1番目のディスクにのみ有効
 
   // networks
   repeated NIC network_interfaces = 19;
 
   // misc
-  string cd_rom_id                = 20;
-  string interface_driver         = 21;
+  string cd_rom_id        = 20;
+  string interface_driver = 21;
 
   // common
-  string name                     = 22;
-  repeated string tags            = 23;
-  string description              = 24;
-  string icon_id                  = 25;
-  bool shutdown_force             = 26;
+  string          name           = 22;
+  repeated string tags           = 23;
+  string          description    = 24;
+  string          icon_id        = 25;
+  bool            shutdown_force = 26;
 
   // ******** messages ***********
 
   message Disk {
     reserved 1 to 10;
 
-    string id                = 11; // 新規作成指示時は空
-    string zone              = 12;
+    string id   = 11;  // 新規作成指示時は空
+    string zone = 12;
 
     // sources
     string source_archive_id = 13;
     string source_disk_id    = 14;
 
     // spec
-    string plan              = 15; // ssd or hdd
-    string connection        = 16; // virtio or ide
-    uint32 size              = 17;
+    string plan       = 15;  // ssd or hdd
+    string connection = 16;  // virtio or ide
+    uint32 size       = 17;
 
     // common
-    string name              = 18;
-    repeated string tags     = 19;
-    string description       = 20;
-    string icon_id           = 21;
+    string          name        = 18;
+    repeated string tags        = 19;
+    string          description = 20;
+    string          icon_id     = 21;
   }
 
   message EditParameter {
     reserved 1 to 10;
 
-    string host_name           = 11;
-    string password            = 12;
-    bool disable_password_auth = 13;
-    bool enable_dhcp           = 14;
-    bool change_partition_uuid = 15;
+    string host_name             = 11;
+    string password              = 12;
+    bool   disable_password_auth = 13;
+    bool   enable_dhcp           = 14;
+    bool   change_partition_uuid = 15;
 
-    string ip_address          = 16;
-    uint32 network_mask_len    = 17;
-    string default_route       = 18;
+    string ip_address       = 16;
+    uint32 network_mask_len = 17;
+    string default_route    = 18;
 
     repeated string ssh_keys    = 19;
     repeated string ssh_key_ids = 20;
@@ -201,11 +201,11 @@ message ServerGroupInstance {
   message NIC {
     reserved 1 to 10;
 
-    string upstream              = 11;
-    string packet_filter_id      = 12;
-    string user_ip_address       = 13;
+    string      upstream         = 11;
+    string      packet_filter_id = 12;
+    string      user_ip_address  = 13;
     NetworkInfo assigned_network = 14;
-    ExposeInfo expose_info       = 15;
+    ExposeInfo  expose_info      = 15;
   }
 
   // NICに紐づくネットワーク公開情報
@@ -213,13 +213,13 @@ message ServerGroupInstance {
   message ExposeInfo {
     reserved 1 to 10;
 
-    repeated uint32 ports    = 11;
-    string server_group_name = 12; // ELB向け
-    uint32 weight            = 13; // GSLB向け
-    repeated string vips     = 14; // LB向け
-    HealthCheck health_check = 15; // LB向け
-    string record_name       = 16; // DNS向け
-    uint32 ttl               = 17; // DNS向け
+    repeated uint32 ports             = 11;
+    string          server_group_name = 12;  // ELB向け
+    uint32          weight            = 13;  // GSLB向け
+    repeated string vips              = 14;  // LB向け
+    HealthCheck     health_check      = 15;  // LB向け
+    string          record_name       = 16;  // DNS向け
+    uint32          ttl               = 17;  // DNS向け
   }
 
   message HealthCheck {
@@ -233,7 +233,7 @@ message ServerGroupInstance {
 
 message ELB {
   reserved 2 to 10;
-  Parent parent             = 1;
+  Parent parent = 1;
 
   string id                 = 11;
   string region             = 12;
@@ -246,26 +246,25 @@ message ELB {
 message GSLB {
   reserved 1 to 10;
 
-  string id                   = 11;
-  string fqdn                 = 12;
+  string              id      = 11;
+  string              fqdn    = 12;
   repeated GSLBServer servers = 13;
-  string name                 = 14;
+  string              name    = 14;
 }
 
 message GSLBServer {
   reserved 1 to 10;
 
   string ip_address = 11;
-  bool enabled      = 12;
+  bool   enabled    = 12;
   uint32 weight     = 13;
 }
-
 
 message DNS {
   reserved 1 to 10;
 
-  string id                   = 11;
-  string zone                 = 12;
+  string          id          = 11;
+  string          zone        = 12;
   repeated string dns_servers = 13;
 }
 
@@ -281,34 +280,34 @@ message Router {
 message LoadBalancer {
   reserved 1 to 10;
 
-  string id                                     = 11;
-  string zone                                   = 12;
+  string                   id                   = 11;
+  string                   zone                 = 12;
   repeated LoadBalancerVIP virtual_ip_addresses = 13;
-  string name                                   = 14;
+  string                   name                 = 14;
 }
 
 message LoadBalancerVIP {
   reserved 1 to 10;
 
-  string ip_address                   = 11;
-  uint32 port                         = 12;
-  repeated LoadBalancerServer servers = 13;
+  string                      ip_address = 11;
+  uint32                      port       = 12;
+  repeated LoadBalancerServer servers    = 13;
 }
 
 message LoadBalancerServer {
   reserved 1 to 10;
 
   string ip_address = 11;
-  bool enabled      = 12;
+  bool   enabled    = 12;
 }
 
 message Parent {
   reserved 1 to 10;
 
   oneof resource {
-    ELB elb                    = 11;
-    GSLB gslb                  = 12;
-    DNS dns                    = 13;
+    ELB          elb           = 11;
+    GSLB         gslb          = 12;
+    DNS          dns           = 13;
     LoadBalancer load_balancer = 14;
   }
 }

--- a/protos/request.proto
+++ b/protos/request.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+syntax            = "proto3";
 option go_package = "github.com/sacloud/autoscaler/request";
 
 package autoscaler;
@@ -15,27 +15,28 @@ service ScalingService {
 
 // Scalingサービスのリクエストパラメータ
 message ScalingRequest {
-  // 呼び出し元を示すラベル値、Coreでの処理には影響しない。デフォルト値: "default"
-  string source              = 1;
+  // 呼び出し元を示すラベル値、Coreでの処理には影響しない。デフォルト値:
+  // "default"
+  string source = 1;
 
   // 操作対象のリソース名。リソース名にはCoreのコンフィギュレーションの中で定義した名前を指定する
   // 対応するリソース名がCoreで見つけられなかった場合はエラーを返す
   //
   // デフォルト値: "default"
   // デフォルト値を指定した場合はCoreのコンフィギュレーションで定義された先頭のリソースが操作対象となる
-  string resource_name       = 2;
+  string resource_name = 2;
 
   // 希望するスケール(プランなど)につけた名前
   // 特定のスケールに一気にスケールを変更したい場合に指定する
   // 指定する名前はCoreのコンフィギュレーションで定義しておく必要がある
-  string desired_state_name  = 3;
+  string desired_state_name = 3;
 }
 
 // Scalingサービスのレスポンス
 message ScalingResponse {
   // スケールジョブのID
   // リクエストパラメータに応じてCoreがジョブを起動しIDを割り当てたもの
-  string scaling_job_id   = 1;
+  string scaling_job_id = 1;
 
   // スケールジョブのステータス
   // Coreがリクエストを処理した段階のステータスを返す
@@ -43,16 +44,16 @@ message ScalingResponse {
 
   // Coreからのメッセージ
   // 何らかの事情でリクエストを受け付けられなかった場合の理由が記載される
-  string message          = 3;
+  string message = 3;
 }
 
 // ジョブのステータス
 enum ScalingJobStatus {
-  JOB_UNKNOWN         = 0;
-  JOB_ACCEPTED        = 1;
-  JOB_RUNNING         = 2;
-  JOB_DONE            = 3;
-  JOB_CANCELED        = 4;
-  JOB_IGNORED         = 5;
-  JOB_FAILED          = 6;
+  JOB_UNKNOWN  = 0;
+  JOB_ACCEPTED = 1;
+  JOB_RUNNING  = 2;
+  JOB_DONE     = 3;
+  JOB_CANCELED = 4;
+  JOB_IGNORED  = 5;
+  JOB_FAILED   = 6;
 }


### PR DESCRIPTION
clang-formatで`.proto`のフォーマットを行う。

参考にしたサイト: https://christina04.hatenablog.com/entry/protobuf-formatter

現在は`.proto`の修正は頻繁ではないためCIには組み込まず必要に応じて各開発機に手動でインストールする形とする。