### PR TITLE
Make ResourceName required when configuration has more than one resource definition

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -198,11 +198,14 @@ func (c *Core) handle(ctx *RequestContext) (*JobStatus, string, error) {
 	return job, "", nil
 }
 
-func (c *Core) ResourceName(name string) string {
+func (c *Core) ResourceName(name string) (string, error) {
 	if name == "" || name == defaults.ResourceName {
+		if len(c.config.Resources) > 1 {
+			return "", fmt.Errorf("request parameter 'ResourceName' is required when core's configuration has more than one resource definition")
+		}
 		name = c.config.Resources[0].Name()
 	}
-	return name
+	return name, nil
 }
 
 func (c *Core) targetResourceDef(ctx *RequestContext) (ResourceDefinitions, error) {

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -1,0 +1,113 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"testing"
+
+	"github.com/sacloud/autoscaler/defaults"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCore_ResourceName(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources ResourceDefinitions
+		args      string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name: "empty resource name with a definition",
+			resources: ResourceDefinitions{
+				&stubResourceDef{
+					ResourceDefBase: &ResourceDefBase{TypeName: "stub", DefName: "name1"},
+				},
+			},
+			args:    "",
+			want:    "name1",
+			wantErr: false,
+		},
+		{
+			name: "default resource name with a definition",
+			resources: ResourceDefinitions{
+				&stubResourceDef{
+					ResourceDefBase: &ResourceDefBase{TypeName: "stub", DefName: "name1"},
+				},
+			},
+			args:    defaults.ResourceName,
+			want:    "name1",
+			wantErr: false,
+		},
+		{
+			name: "empty resource name with definitions",
+			resources: ResourceDefinitions{
+				&stubResourceDef{
+					ResourceDefBase: &ResourceDefBase{TypeName: "stub", DefName: "name1"},
+				},
+				&stubResourceDef{
+					ResourceDefBase: &ResourceDefBase{TypeName: "stub", DefName: "name2"},
+				},
+			},
+			args:    "",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "default resource name with definitions",
+			resources: ResourceDefinitions{
+				&stubResourceDef{
+					ResourceDefBase: &ResourceDefBase{TypeName: "stub", DefName: "name1"},
+				},
+				&stubResourceDef{
+					ResourceDefBase: &ResourceDefBase{TypeName: "stub", DefName: "name2"},
+				},
+			},
+			args:    defaults.ResourceName,
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "not exist name with definitions",
+			resources: ResourceDefinitions{
+				&stubResourceDef{
+					ResourceDefBase: &ResourceDefBase{TypeName: "stub", DefName: "name1"},
+				},
+				&stubResourceDef{
+					ResourceDefBase: &ResourceDefBase{TypeName: "stub", DefName: "name2"},
+				},
+			},
+			args:    "name3",
+			want:    "name3",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Core{
+				listenAddress: defaults.CoreSocketAddr,
+				config: &Config{
+					Resources: tt.resources,
+				},
+			}
+			got, err := c.ResourceName(tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ResourceName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/core/service.go
+++ b/core/service.go
@@ -43,11 +43,16 @@ func (s *ScalingService) Up(ctx context.Context, req *request.ScalingRequest) (*
 		return nil, err
 	}
 
+	resourceName, err := s.instance.ResourceName(req.ResourceName)
+	if err != nil {
+		return nil, err
+	}
+
 	// リクエストには即時応答を返しつつバックグラウンドでジョブを実行するために引数のctxは引き継がない
 	serviceCtx := NewRequestContext(context.Background(), &requestInfo{
 		requestType:      requestTypeUp,
 		source:           req.Source,
-		resourceName:     s.instance.ResourceName(req.ResourceName),
+		resourceName:     resourceName,
 		desiredStateName: req.DesiredStateName,
 	}, s.instance.config.AutoScaler.HandlerTLSConfig, s.instance.logger)
 	job, message, err := s.instance.Up(serviceCtx)
@@ -69,11 +74,16 @@ func (s *ScalingService) Down(ctx context.Context, req *request.ScalingRequest) 
 		return nil, err
 	}
 
+	resourceName, err := s.instance.ResourceName(req.ResourceName)
+	if err != nil {
+		return nil, err
+	}
+
 	// リクエストには即時応答を返しつつバックグラウンドでジョブを実行するために引数のctxは引き継がない
 	serviceCtx := NewRequestContext(context.Background(), &requestInfo{
 		requestType:      requestTypeDown,
 		source:           req.Source,
-		resourceName:     s.instance.ResourceName(req.ResourceName),
+		resourceName:     resourceName,
 		desiredStateName: req.DesiredStateName,
 	}, s.instance.config.AutoScaler.HandlerTLSConfig, s.instance.logger)
 	job, message, err := s.instance.Down(serviceCtx)


### PR DESCRIPTION
closes #215 

複数のリソースが定義されている場合、InputsからのResourceNameパラメータを必須(デフォルト値の場合は指定されていないとみなす)にする。