### PR TITLE
Added local-exec handler

### DIFF
--- a/commands/handlers/handlers.go
+++ b/commands/handlers/handlers.go
@@ -1,0 +1,34 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"github.com/sacloud/autoscaler/commands/handlers/localexec"
+	"github.com/spf13/cobra"
+)
+
+var Command = &cobra.Command{
+	Use:           "handlers",
+	Short:         "A set of sub commands to manage autoscaler's external handlers",
+	SilenceErrors: true,
+}
+
+var subCommands = []*cobra.Command{
+	localexec.Command,
+}
+
+func init() {
+	Command.AddCommand(subCommands...)
+}

--- a/commands/handlers/localexec/cmd.go
+++ b/commands/handlers/localexec/cmd.go
@@ -1,0 +1,65 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localexec
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+
+	"github.com/sacloud/autoscaler/commands/flags"
+	"github.com/sacloud/autoscaler/handlers"
+	"github.com/sacloud/autoscaler/handlers/localexec"
+	"github.com/sacloud/autoscaler/validate"
+	"github.com/spf13/cobra"
+)
+
+var Command = &cobra.Command{
+	Use:   "local-exec [flags]... {path/to/your/executable}",
+	Short: "Handler for executing a shell script",
+	Args:  cobra.NoArgs,
+	PreRunE: flags.ValidateMultiFunc(true,
+		func(*cobra.Command, []string) error {
+			return validate.Struct(param)
+		},
+	),
+	RunE: run,
+}
+
+type parameter struct {
+	ExecutablePath string `name:"--executable-path" validate:"required,file"`
+	HandlerType    string `name:"--handler-type" validate:"required,oneof=pre-handle handle post-handle"`
+	ListenAddr     string `name:"--addr" validate:"required,printascii"`
+	Config         string `name:"--config" validate:"omitempty,file"`
+}
+
+var param = &parameter{
+	ListenAddr: "unix:autoscaler-handlers-local-exec.sock",
+}
+
+func init() {
+	Command.Flags().StringVarP(&param.ListenAddr, "addr", "", param.ListenAddr, "the address for the server to listen on")
+	Command.Flags().StringVarP(&param.ExecutablePath, "executable-path", "", param.ExecutablePath, "Path to the executable")
+	Command.Flags().StringVarP(&param.HandlerType, "handler-type", "", param.HandlerType, "Handler type name")
+	Command.Flags().StringVarP(&param.Config, "config", "", param.Config, "Filepath to Handlers additional configuration file")
+}
+
+func run(*cobra.Command, []string) error {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	handler := localexec.NewHandler(param.ListenAddr, param.Config, param.ExecutablePath, param.HandlerType, flags.NewLogger())
+	return handlers.Serve(ctx, handler)
+}

--- a/commands/root.go
+++ b/commands/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sacloud/autoscaler/commands/completion"
 	"github.com/sacloud/autoscaler/commands/core"
 	"github.com/sacloud/autoscaler/commands/flags"
+	"github.com/sacloud/autoscaler/commands/handlers"
 	"github.com/sacloud/autoscaler/commands/inputs"
 	cmdVersion "github.com/sacloud/autoscaler/commands/version"
 	"github.com/sacloud/autoscaler/version"
@@ -40,6 +41,7 @@ var subCommands = []*cobra.Command{
 	inputs.Command,
 	core.Command,
 	cmdVersion.Command,
+	handlers.Command,
 }
 
 func init() {

--- a/core/config.go
+++ b/core/config.go
@@ -115,6 +115,8 @@ func (c *Config) Validate(ctx context.Context) error {
 	// 変更される可能性があるためこのタイミングで初期化する
 	validate.InitValidatorAlias(sacloud.SakuraCloudZones)
 
+	// TODO カスタムHandlerとの疎通チェック
+
 	// Resources
 	errors := &multierror.Error{}
 	if errs := c.Resources.Validate(ctx, c.APIClient()); len(errs) > 0 {

--- a/core/handler.go
+++ b/core/handler.go
@@ -314,13 +314,18 @@ func (h *Handler) handleHandlerResponse(ctx *HandlingContext, receiver handlerRe
 		if err != nil {
 			return err
 		}
-		if err := ctx.Logger().Info("status", stat.Status); err != nil {
-			return err
-		}
+		kvs := []interface{}{"status", stat.Status}
 		if stat.Log != "" {
-			if err := ctx.Logger().Debug("log", stat.Log); err != nil {
+			kvs = append(kvs, "log", stat.Log)
+		}
+
+		if stat.Status == handler.HandleResponse_IGNORED && stat.Log == "" {
+			if err := ctx.Logger().Debug(kvs...); err != nil {
 				return err
 			}
+		}
+		if err := ctx.Logger().Info(kvs...); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/examples/custom-handler/handler.sh
+++ b/examples/custom-handler/handler.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright 2021 The sacloud Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#******************************************************************************
+# local-execハンドラの利用例
+#******************************************************************************
+# 以下のように起動する
+# $ autoscaler handlers local-exec --executable-path handler.sh --handler-type handle
+#
+# Coreのコンフィギュレーションで以下のようにカスタムハンドラを登録しておく
+#
+# handlers:
+#   - name: "local-exec"
+#     endpoint: "unix:autoscaler-handlers-local-exec.sock
+#
+#******************************************************************************
+#
+# local-execハンドラへは標準入力経由でパラメータが渡される
+#   パラメータの詳細: protos/handler.proto
+#
+# - 終了コードに0以外を返すとエラーとみなす
+# - 標準出力に何か書き込むとCoreのログに出力される
+# - 標準エラーへの書き込みは無視される
+#******************************************************************************
+
+# 例: 標準入力に渡された内容をそのまま標準出力へ出力する
+# 出力した内容はCoreとlocal-execハンドラのログに出力される
+cat

--- a/handler/customize.go
+++ b/handler/customize.go
@@ -14,6 +14,8 @@
 
 package handler
 
+import "encoding/json"
+
 func (x *ServerGroupInstance_NIC) EachIPAndExposedPort(fn func(ip string, port int) error) error {
 	if x == nil || x.ExposeInfo == nil || x.AssignedNetwork == nil {
 		return nil
@@ -25,4 +27,26 @@ func (x *ServerGroupInstance_NIC) EachIPAndExposedPort(fn func(ip string, port i
 		}
 	}
 	return nil
+}
+
+func (x *HandleRequest) JSON() []byte {
+	if x == nil {
+		return nil
+	}
+	data, err := json.Marshal(x)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+func (x *PostHandleRequest) JSON() []byte {
+	if x == nil {
+		return nil
+	}
+	data, err := json.Marshal(x)
+	if err != nil {
+		return nil
+	}
+	return data
 }

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -22,6 +22,12 @@ import (
 	"github.com/sacloud/autoscaler/metrics"
 )
 
+const (
+	HandlerTypePreHandle  = "pre-handle"
+	HandlerTypeHandle     = "handle"
+	HandlerTypePostHandle = "post-handle"
+)
+
 // Serve 指定のハンドラでgRPCサーバをスタート/リッスンする
 func Serve(ctx context.Context, handler CustomHandler) error {
 	handler.SetLogger(handler.GetLogger().With("from", handlerFullName(handler)))

--- a/handlers/localexec/local_exec_handler.go
+++ b/handlers/localexec/local_exec_handler.go
@@ -1,0 +1,120 @@
+// Copyright 2021 The sacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localexec
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+
+	"github.com/sacloud/autoscaler/handler"
+	"github.com/sacloud/autoscaler/handlers"
+	"github.com/sacloud/autoscaler/log"
+	"github.com/sacloud/autoscaler/version"
+)
+
+type Handler struct {
+	handlers.HandlerLogger
+	listenAddress  string
+	tlsConfigPath  string
+	executablePath string
+	handlerType    string
+}
+
+// NewHandler .
+func NewHandler(listenAddr, tlsConfigPath, executable, handlerType string, logger *log.Logger) *Handler {
+	return &Handler{
+		HandlerLogger:  handlers.HandlerLogger{Logger: logger},
+		listenAddress:  listenAddr,
+		tlsConfigPath:  tlsConfigPath,
+		executablePath: executable,
+		handlerType:    handlerType,
+	}
+}
+
+// Name ハンドラ名、"autoscaler-handlers-"というプレフィックスをつけない短い名前を返す
+func (h *Handler) Name() string {
+	return "local-exec"
+}
+
+// Version .
+func (h *Handler) Version() string {
+	return version.FullVersion()
+}
+
+// ListenAddress CustomHandlerインターフェースの実装
+func (h *Handler) ListenAddress() string {
+	return h.listenAddress
+}
+
+// ConfigPath CustomHandlerインターフェースの実装
+func (h *Handler) ConfigPath() string {
+	return h.tlsConfigPath
+}
+
+func (h *Handler) PreHandle(req *handler.HandleRequest, sender handlers.ResponseSender) error {
+	if h.handlerType == handlers.HandlerTypePreHandle {
+		ctx := handlers.NewHandlerContext(req.ScalingJobId, sender)
+		return h.handle(ctx, req.JSON())
+	}
+	return h.GetLogger().Info("status", handler.HandleResponse_IGNORED)
+}
+
+func (h *Handler) Handle(req *handler.HandleRequest, sender handlers.ResponseSender) error {
+	if h.handlerType == handlers.HandlerTypeHandle {
+		ctx := handlers.NewHandlerContext(req.ScalingJobId, sender)
+		return h.handle(ctx, req.JSON())
+	}
+	return h.GetLogger().Info("status", handler.HandleResponse_IGNORED)
+}
+
+func (h *Handler) PostHandle(req *handler.PostHandleRequest, sender handlers.ResponseSender) error {
+	if h.handlerType == handlers.HandlerTypePostHandle {
+		ctx := handlers.NewHandlerContext(req.ScalingJobId, sender)
+		return h.handle(ctx, req.JSON())
+	}
+	return h.GetLogger().Info("status", handler.HandleResponse_IGNORED)
+}
+
+func (h *Handler) handle(ctx *handlers.HandlerContext, req []byte) error {
+	logger := h.GetLogger()
+	if err := logger.Debug("status", handler.HandleResponse_RECEIVED); err != nil {
+		return err
+	}
+	if err := logger.Debug("request", string(req)); err != nil {
+		return err
+	}
+
+	return h.execute(ctx, req)
+}
+
+func (h *Handler) execute(ctx *handlers.HandlerContext, args []byte) error {
+	cmd := exec.Command(h.executablePath, string(args))
+	argsReader := bytes.NewReader(args)
+	cmd.Stdin = argsReader
+
+	output, err := cmd.Output()
+	if err != nil {
+		wrapped := fmt.Errorf("command %q returned non zero status: %s", h.executablePath, err)
+		if err := h.GetLogger().Error("error", wrapped); err != nil {
+			return err
+		}
+		return wrapped
+	}
+	if err := h.GetLogger().Info("status", handler.HandleResponse_DONE, "output", string(output)); err != nil {
+		return err
+	}
+	return ctx.Report(handler.HandleResponse_DONE, string(output))
+}


### PR DESCRIPTION
closes #41 

任意のシェルスクリプトなどを実行するためのハンドラーを追加する。

sacloud/autoscalerの水平スケールでは基本的にソースアーカイブをPackerなどで作り込んでおく or スタートアップスクリプトでプロビジョニングすることを想定しているが、パブリックアーカイブ以外のソースを利用する場合でもスケールアップ後に任意のプロビジョニングを実行したいことがある。

これを実現するために、任意のスクリプトを実行可能なハンドラーを追加して対応する。
ハンドラーは起動したホスト上で任意の実行可能ファイルを実行することでプロビジョニングなどを行う。

このハンドラはautoscalerに組み込むが、ビルトインハンドラではなくカスタムハンドラとしてのみ提供する。
このため、利用したい場合は個別にハンドラーを起動し、Coreのコンフィギュレーションでカスタムハンドラーを定義する必要がある。

利用例:

```bash
$ autoscaler handlers local-exec --executable-path /your/provisioning/script.sh --handler-type handle
```

### 仕様

- `--executable-path`には任意の実行可能ファイルへのパスを指定する
- `--handler-type`には以下のいずれかを指定する。指定した値に対応するタイミングでのみ実行されるようになる。
  - pre-handle
  - handle
  - post-handle
- 実行可能ファイルへは標準入力経由で処理対象リソースの情報が渡される。
  渡されるパラメータは https://github.com/sacloud/autoscaler/blob/main/protos/handler.proto のHandleRequest、またはPostHandleRequest をJSONにしたもの
- 実行可能ファイルが終了コード0を返した場合は処理成功とみなす
- 標準出力に出力した内容はCoreのログに出力される
- 標準エラーへの出力は無視される