### PR TITLE
Remove usacloud from e2e docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ e2e-test:
 	    -e SAKURACLOUD_ACCESS_TOKEN \
 	    -e SAKURACLOUD_ACCESS_TOKEN_SECRET \
 	    -e SKIP_CLEANUP \
-	    ghcr.io/sacloud/autoscaler:e2e sh -c "cd e2e;./run.sh"
+	    ghcr.io/sacloud/autoscaler:e2e sh -c "./run.sh"
 
 .PHONY: lint
 lint:

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -31,11 +31,6 @@ RUN wget https://releases.hashicorp.com/terraform/1.0.2/terraform_1.0.2_linux_am
 RUN unzip terraform_1.0.2_linux_amd64.zip && rm terraform_1.0.2_linux_amd64.zip
 RUN mv terraform /usr/bin/terraform
 
-# Install Usacloud
-RUN wget https://github.com/sacloud/usacloud/releases/download/v1.2.0/usacloud_linux-amd64.zip
-RUN unzip usacloud_linux-amd64.zip && rm usacloud_linux-amd64.zip
-RUN mv usacloud /usr/bin/usacloud
-
 # Install grpc_health_probe
 
 RUN go install github.com/grpc-ecosystem/grpc-health-probe@v0.4.2

--- a/e2e/e2e.tf
+++ b/e2e/e2e.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     sakuracloud = {
       source  = "sacloud/sakuracloud"
-      version = "2.10.0"
+      version = "2.11.0"
     }
   }
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -51,10 +51,11 @@ const (
 )
 
 var (
-	coreCmd  = exec.Command("autoscaler", "server", "start")
-	inputCmd = exec.Command("autoscaler", "inputs", "grafana", "--addr", "127.0.0.1:8080")
-	outputs  []string
-	mu       sync.Mutex
+	coreCmd    = exec.Command("autoscaler", "server", "start")
+	inputCmd   = exec.Command("autoscaler", "inputs", "grafana", "--addr", "127.0.0.1:8080")
+	refreshCmd = exec.Command("terraform", "refresh")
+	outputs    []string
+	mu         sync.Mutex
 
 	proxyLBReadyTimeout = 5 * time.Minute
 	e2eTestTimeout      = 20 * time.Minute
@@ -186,6 +187,9 @@ func TestE2E(t *testing.T) {
 	// 冷却期間待機
 	time.Sleep(30 * time.Second)
 
+	// Terraformステートのリフレッシュ(複数回IDが変更されるため毎回リフレッシュしておく)
+	refreshCmd.Run() // nolint
+
 	/**************************************************************************
 	 * Step 2-1: スケールダウン
 	 *************************************************************************/
@@ -220,6 +224,8 @@ func TestE2E(t *testing.T) {
 			),
 		)
 	}
+	// Terraformステートのリフレッシュ(複数回IDが変更されるため毎回リフレッシュしておく)
+	refreshCmd.Run() // nolint
 }
 
 func setup() {

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -17,12 +17,12 @@
 set -x
 
 : "Provisioning Infrastructures on SAKURA Cloud..."
+rm -rf .terraform*
+rm -f terraform.tfstate*
 terraform init
 terraform apply -auto-approve
 
 : "Setting up..."
-rm -rf .terraform*
-rm -f terraform.tfstate*
 rm -f autoscaler.sock
 
 : "Running e2e test..."
@@ -33,9 +33,7 @@ if [ -n "$SKIP_CLEANUP" ]; then
 : "Cleanup skipped"
 else
 : "Cleaning up Infrastructures..."
-usacloud server delete -y -f --zone is1a --with-disks `usacloud server list -q --zone is1a --names autoscaler-e2e-test` > /dev/null 2>&1
-usacloud proxy-lb delete -y `usacloud proxy-lb list -q --names autoscaler-e2e-test` > /dev/null 2>&1
-usacloud startup-script delete -y `usacloud startup-script list -q --names autoscaler-e2e-test` > /dev/null 2>&1
+terraform destroy -auto-approve
 fi
 
 echo "Done: $RESULT"


### PR DESCRIPTION
closes #219 

e2e環境向けのDockerイメージからusacloudを除去する。

- リソースの削除には@previous-idタグに対応したterraform-provider-sakuracloud v2.11+を利用
- Terraformはリソース作成/削除のみに利用するためlifecycleメタタグは付与しない
- 複数回のプラン変更(ID変更)が発生するため、テストコードの中から`terraform refresh`を実行する