### PR TITLE
Fixed: calculate desired plan

### DIFF
--- a/core/resource_def_server_group_test.go
+++ b/core/resource_def_server_group_test.go
@@ -618,6 +618,74 @@ func TestResourceDefServerGroup_desiredPlan(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name: "up: currentCount has smaller value than min_size",
+			fields: fields{
+				MinSize: 1,
+				MaxSize: 3,
+				Plans:   nil,
+			},
+			args: args{
+				ctx:          testContext(),
+				currentCount: 0,
+			},
+			want: &ServerGroupPlan{
+				Name: "",
+				Size: 1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "up: currentCount has larger value than max_size",
+			fields: fields{
+				MinSize: 1,
+				MaxSize: 3,
+				Plans:   nil,
+			},
+			args: args{
+				ctx:          testContext(),
+				currentCount: 4,
+			},
+			want: &ServerGroupPlan{
+				Name: "",
+				Size: 4,
+			},
+			wantErr: false,
+		},
+		{
+			name: "down with resources that are outside the scope of the plans:max",
+			fields: fields{
+				MinSize: 1,
+				MaxSize: 3,
+				Plans:   nil,
+			},
+			args: args{
+				ctx:          testContextDown(),
+				currentCount: 4,
+			},
+			want: &ServerGroupPlan{
+				Name: "",
+				Size: 3,
+			},
+			wantErr: false,
+		},
+		{
+			name: "down with resources that are outside the scope of the plans:min",
+			fields: fields{
+				MinSize: 1,
+				MaxSize: 3,
+				Plans:   nil,
+			},
+			args: args{
+				ctx:          testContextDown(),
+				currentCount: 0,
+			},
+			want: &ServerGroupPlan{
+				Name: "",
+				Size: 0,
+			},
+			wantErr: false,
+		},
+		{
 			name: "up without plans / without servers on cloud",
 			fields: fields{
 				MinSize: 0,
@@ -703,7 +771,7 @@ func TestResourceDefServerGroup_desiredPlan(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "down without plans / with invalid server state", // max_sizeを超えたサーバがある場合は特に何もしない
+			name: "down without plans / with invalid server state", // max_sizeを超えたサーバがある場合のdownはmax_sizeを返す
 			fields: fields{
 				MinSize: 0,
 				MaxSize: 1,
@@ -715,7 +783,7 @@ func TestResourceDefServerGroup_desiredPlan(t *testing.T) {
 			},
 			want: &ServerGroupPlan{
 				Name: "",
-				Size: 2,
+				Size: 1,
 			},
 			wantErr: false,
 		},

--- a/core/resource_plans.go
+++ b/core/resource_plans.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sacloud/autoscaler/defaults"
 )
 
-// ResourcePlan 垂直スケールをサポートするリソースでのプランを表すインターフェース
+// ResourcePlan オートスケールをサポートするリソースでのプランを表すインターフェース
 type ResourcePlan interface {
 	// PlanName プラン名、Configurationで任意のプランに任意の名前をつけるために利用する
 	PlanName() string
@@ -33,7 +33,7 @@ type ResourcePlan interface {
 	LessThanPlan(plans ResourcePlan) bool
 }
 
-// ResourcePlans 垂直スケールをサポートするリソースでのプラン一覧を表すインターフェース
+// ResourcePlans オートスケールをサポートするリソースでのプラン一覧を表すインターフェース
 type ResourcePlans []ResourcePlan
 
 // Sort ResourcePlan.LessThanPlanを用いて昇順にソートする
@@ -58,6 +58,15 @@ func (p *ResourcePlans) Next(resource interface{}) ResourcePlan {
 		return nil
 	}
 
+	if !plans.within(resource) {
+		// resourceがplansの最小より小さい値を持つ場合
+		// 例: plans == [2,4,8], resource == 1 の場合、plansの最初(plans=2)を返す
+		if !plans[0].LessThan(resource) {
+			return plans[0]
+		}
+		return nil
+	}
+
 	next := false
 	for _, plan := range plans {
 		if plan.Equals(resource) || plan.LessThan(resource) {
@@ -68,6 +77,7 @@ func (p *ResourcePlans) Next(resource interface{}) ResourcePlan {
 			return plan
 		}
 	}
+
 	return nil
 }
 
@@ -84,6 +94,16 @@ func (p *ResourcePlans) Prev(resource interface{}) ResourcePlan {
 		return nil
 	}
 
+	if !plans.within(resource) {
+		// resourceがplansの最大より大きな値を持つ場合
+		// 例: plans == [2,4,8], resource == 10 の場合、plansの最後(plans=8)を返す
+		plan := plans[len(plans)-1]
+		if !plan.Equals(resource) && plan.LessThan(resource) {
+			return plan
+		}
+		return nil
+	}
+
 	var prev ResourcePlan
 	for i, plan := range plans {
 		if i > 0 && (plan.Equals(resource) || !plan.LessThan(resource)) {
@@ -95,6 +115,27 @@ func (p *ResourcePlans) Prev(resource interface{}) ResourcePlan {
 		return nil
 	}
 	return prev
+}
+
+func (p *ResourcePlans) within(resource interface{}) bool {
+	plans := *p
+	switch len(plans) {
+	case 0:
+		return false
+	case 1:
+		return plans[0].Equals(resource)
+	default:
+		first := plans[0]
+		last := plans[len(plans)-1]
+		// first <= resource <= last であればtrue
+		if !(first.Equals(resource) || first.LessThan(resource)) {
+			return false
+		}
+		if !last.Equals(resource) && last.LessThan(resource) {
+			return false
+		}
+		return true
+	}
 }
 
 func desiredPlan(ctx *RequestContext, current interface{}, plans ResourcePlans) (ResourcePlan, error) {

--- a/core/resource_plans_test.go
+++ b/core/resource_plans_test.go
@@ -269,3 +269,105 @@ func Test_desiredPlan(t *testing.T) {
 		})
 	}
 }
+
+func TestResourcePlans_within(t *testing.T) {
+	type args struct {
+		resource interface{}
+	}
+	tests := []struct {
+		name string
+		p    ResourcePlans
+		args args
+		want bool
+	}{
+		{
+			name: "empty plans",
+			p:    ResourcePlans{},
+			args: args{
+				resource: 1,
+			},
+			want: false,
+		},
+		{
+			name: "single plan: less than",
+			p: ResourcePlans{
+				&stubResourcePlan{memorySize: 1},
+			},
+			args: args{
+				resource: 0,
+			},
+			want: false,
+		},
+		{
+			name: "single plan: equals",
+			p: ResourcePlans{
+				&stubResourcePlan{memorySize: 1},
+			},
+			args: args{
+				resource: 1,
+			},
+			want: true,
+		},
+		{
+			name: "single plan: greater than",
+			p: ResourcePlans{
+				&stubResourcePlan{memorySize: 1},
+			},
+			args: args{
+				resource: 2,
+			},
+			want: false,
+		},
+		{
+			name: "plans: less than",
+			p: ResourcePlans{
+				&stubResourcePlan{memorySize: 1},
+				&stubResourcePlan{memorySize: 2},
+			},
+			args: args{
+				resource: 0,
+			},
+			want: false,
+		},
+		{
+			name: "plans: within 1",
+			p: ResourcePlans{
+				&stubResourcePlan{memorySize: 1},
+				&stubResourcePlan{memorySize: 2},
+			},
+			args: args{
+				resource: 1,
+			},
+			want: true,
+		},
+		{
+			name: "plans: within 2",
+			p: ResourcePlans{
+				&stubResourcePlan{memorySize: 1},
+				&stubResourcePlan{memorySize: 2},
+			},
+			args: args{
+				resource: 2,
+			},
+			want: true,
+		},
+		{
+			name: "plans: out: greater than",
+			p: ResourcePlans{
+				&stubResourcePlan{memorySize: 1},
+				&stubResourcePlan{memorySize: 2},
+			},
+			args: args{
+				resource: 3,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.p.within(tt.args.resource); got != tt.want {
+				t.Errorf("within() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
closes #216 

Desired Planの算出の際、現在の値が対象プラン範囲外の場合のUp/Downで意図しない結果になってしまう問題を修正