### PR TITLE
Validate resource name for nested definitions

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -200,7 +200,7 @@ func (c *Core) handle(ctx *RequestContext) (*JobStatus, string, error) {
 
 func (c *Core) ResourceName(name string) (string, error) {
 	if name == "" || name == defaults.ResourceName {
-		if len(c.config.Resources) > 1 {
+		if len(c.config.Resources.ResourceNames()) > 1 {
 			return "", fmt.Errorf("request parameter 'ResourceName' is required when core's configuration has more than one resource definition")
 		}
 		name = c.config.Resources[0].Name()

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -80,6 +80,25 @@ func TestCore_ResourceName(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "default resource name with nested definition",
+			resources: ResourceDefinitions{
+				&stubResourceDef{
+					ResourceDefBase: &ResourceDefBase{
+						TypeName: "stub",
+						DefName:  "name1",
+						children: ResourceDefinitions{
+							&stubResourceDef{
+								ResourceDefBase: &ResourceDefBase{TypeName: "stub", DefName: "name2"},
+							},
+						},
+					},
+				},
+			},
+			args:    defaults.ResourceName,
+			want:    "",
+			wantErr: true,
+		},
+		{
 			name: "not exist name with definitions",
 			resources: ResourceDefinitions{
 				&stubResourceDef{

--- a/core/resource_definitions.go
+++ b/core/resource_definitions.go
@@ -53,6 +53,22 @@ func (rds *ResourceDefinitions) Validate(ctx context.Context, apiClient sacloud.
 	return errors
 }
 
+func (rds *ResourceDefinitions) ResourceNames() []string {
+	nameMap := make(map[string]struct{})
+	fn := func(r ResourceDefinition) error {
+		nameMap[r.Name()] = struct{}{}
+		return nil
+	}
+
+	rds.walk(*rds, fn) // nolint
+
+	var names []string
+	for name := range nameMap {
+		names = append(names, name)
+	}
+	return names
+}
+
 type resourceDefWalkFunc func(def ResourceDefinition) error
 
 func (rds *ResourceDefinitions) walk(targets ResourceDefinitions, fn resourceDefWalkFunc) error {


### PR DESCRIPTION
closes #228

子リソースがある場合のリソース名バリデーション誤りの修正