### PR TITLE
Disable builtin handlers

### DIFF
--- a/core/config_test.go
+++ b/core/config_test.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"testing"
 
+	"github.com/goccy/go-yaml"
+
 	"github.com/sacloud/autoscaler/config"
 	"github.com/stretchr/testify/require"
 )
@@ -148,6 +150,99 @@ autoscaler:
 			}
 
 			require.EqualValues(t, expected, c)
+		})
+	}
+}
+
+func TestHandlersConfig_UnmarshalYAML(t *testing.T) {
+	data := []byte(`
+disabled: true
+handlers:
+  foo:
+    disabled: true
+  dns-servers-handler:
+    disabled: true
+`)
+
+	var config HandlersConfig
+	if err := yaml.UnmarshalWithOptions(data, &config); err != nil {
+		t.Fatal(err)
+	}
+	expected := HandlersConfig{
+		Disabled: true,
+		Handlers: map[string]*HandlerConfig{
+			"foo":                 {Disabled: true},
+			"dns-servers-handler": {Disabled: true},
+		},
+	}
+	require.EqualValues(t, expected, config)
+}
+
+func TestConfig_Handlers(t *testing.T) {
+	type fields struct {
+		AutoScaler AutoScalerConfig
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   Handlers
+	}{
+		{
+			name:   "empty",
+			fields: fields{},
+			want:   BuiltinHandlers(),
+		},
+		{
+			name: "disable all",
+			fields: fields{
+				AutoScaler: AutoScalerConfig{
+					HandlersConfig: &HandlersConfig{
+						Disabled: true,
+					},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "disable per handler",
+			fields: fields{
+				AutoScaler: AutoScalerConfig{
+					HandlersConfig: &HandlersConfig{
+						Handlers: map[string]*HandlerConfig{
+							"dns-servers-handler":           {Disabled: false},
+							"elb-vertical-scaler":           {Disabled: false},
+							"elb-servers-handler":           {Disabled: true},
+							"gslb-servers-handler":          {Disabled: true},
+							"load-balancer-servers-handler": {Disabled: true},
+							"router-vertical-scaler":        {Disabled: true},
+							"server-horizontal-scaler":      {Disabled: true},
+							"server-vertical-scaler":        {Disabled: true},
+						},
+					},
+				},
+			},
+			want: []*Handler{
+				{Name: "dns-servers-handler"},
+				{Name: "elb-vertical-scaler"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{
+				SakuraCloud: &SakuraCloud{Credential: Credential{}},
+				AutoScaler:  tt.fields.AutoScaler,
+			}
+			got := c.Handlers()
+
+			var gotNames, wantNames []string
+			for _, h := range got {
+				gotNames = append(gotNames, h.Name)
+			}
+			for _, h := range tt.want {
+				wantNames = append(wantNames, h.Name)
+			}
+			require.EqualValues(t, gotNames, wantNames)
 		})
 	}
 }


### PR DESCRIPTION
closes #221 

Coreのコンフィギュレーションで指定することでビルトインハンドラを無効に出来るようにする。

設定例:

```yaml
autoscaler:
  handlers_config:
    # disabled: true # 全てのビルトインハンドラを無効にする場合
    handlers:
      dns-servers-handler: #ビルトインハンドラ名
        disabled: true
```

- `handlers_config`を追加
- `handlers_config.disabled`で全てのビルトインハンドラを無効化
- 個別のハンドラごとに無効化したい場合は`handlers_config.handlers`配下に設定