### PR TITLE
Replace 'terraform refresh' to 'terraform apply -refresh-only'

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -53,7 +53,7 @@ const (
 var (
 	coreCmd    = exec.Command("autoscaler", "server", "start")
 	inputCmd   = exec.Command("autoscaler", "inputs", "grafana", "--addr", "127.0.0.1:8080")
-	refreshCmd = exec.Command("terraform", "refresh")
+	refreshCmd = exec.Command("terraform", "apply", "-refresh-only", "-auto-approve")
 	outputs    []string
 	mu         sync.Mutex
 


### PR DESCRIPTION
e2eで使用するterraformはv1.0系なため`terraform refresh`ではなく`terraform apply -refresh-only`を利用する。