### PR TITLE
Improve e2e test

### DIFF
--- a/e2e/e2e.tf
+++ b/e2e/e2e.tf
@@ -13,7 +13,7 @@ provider "sakuracloud" {
 
 # Server
 resource "sakuracloud_server" "server" {
-  count = 2
+  count = 3
 
   name   = "autoscaler-e2e-test"
   core   = 1
@@ -40,7 +40,7 @@ resource "sakuracloud_note" "startupscript" {
 }
 
 resource "sakuracloud_disk" "disk" {
-  count             = 2
+  count             = 3
   name              = "autosxaler-e2e-test"
   source_archive_id = data.sakuracloud_archive.ubuntu.id
 }

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -26,7 +26,7 @@ terraform apply -auto-approve
 rm -f autoscaler.sock
 
 : "Running e2e test..."
-go test -v -tags=e2e ./...
+go test -v -tags=e2e -timeout 240m ./...
 RESULT=$?
 
 if [ -n "$SKIP_CLEANUP" ]; then


### PR DESCRIPTION
closes #252 

ELB配下の実サーバを垂直スケールさせる場合、現在のe2eの構成である実サーバが2台の構成だと全サーバがアクセスできないタイミングが存在する。このためサーバを3台に増やす。

## 詳細

垂直スケールは以下の手順で行われる。

- 1: サーバ1の更新
  - 1-1: ELBの実サーバ設定でサーバ1を`無効`に
  - 1-2: サーバ更新
    - シャットダウン
    - プラン変更
    - 起動
    - 起動完了(Instance.Status == up)まで待機
  - 1-3: ELBの実サーバ設定でサーバ1を`有効`に 
- 2: サーバ2の更新
  - ...

ELBの実サーバ設定を無効にしている間にサーバを更新、その後有効に戻しているが、
有効に戻すタイミングは「APIで取得したサーバの状態が`起動`となった後」となっている。
APIで取得したサーバの状態はIaaS上でサーバの電源投入をした直後から`起動`となるため、サーバ上のWebサーバ(など)が起動していないタイミング(電源投入直後〜OS起動〜サーバ起動)が存在することになる。

これにより、実サーバが2台以下で垂直スケールを行うとタイミング次第で全ての実サーバへのアクセスができず503エラーが返されることになる。
これを防ぐオプションはv0.2時点では提供していない。

## 暫定対応

サーバを3台にすることでこの問題への暫定対応とする。
サーバを増やしても根本的な解決にはならないが、e2eテストのエラーレート改善としては妥当/有用と判断した。

## 根本対応

別途Issueで検討する。