### PR TITLE
inputs: use multiple default values for --dest flag

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -28,3 +28,12 @@ const (
 
 	CoolDownTime = 10 * time.Minute // 同一ジョブの実行制御のための冷却期間
 )
+
+// CoreSocketAddrCandidates CoreのgRPCエンドポイントの候補値のリスト
+//
+// InputsでCoreのエンドポイントアドレスが省略された場合にこれらを上から順に確認し、ファイルの存在が確認できたものから利用される
+var CoreSocketAddrCandidates = []string{
+	CoreSocketAddr,
+	"unix:/var/run/autoscaler.sock",
+	"unix:/var/run/autoscaler/autoscaler.sock",
+}

--- a/grpcutil/server.go
+++ b/grpcutil/server.go
@@ -32,9 +32,9 @@ type ListenerOption struct {
 
 // Server 指定のオプションでリッスン構成をした後でリッスンし、*grpc.Serverとクリーンアップ用のfuncを返す
 func Server(opt *ListenerOption) (*grpc.Server, net.Listener, func(), error) {
-	schema, endpoint, err := parseTarget(opt.Address)
+	schema, endpoint, err := ParseTarget(opt.Address)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("parseTarget failed: %s", err)
+		return nil, nil, nil, fmt.Errorf("ParseTarget failed: %s", err)
 	}
 
 	listener, err := net.Listen(schema, endpoint)

--- a/grpcutil/target.go
+++ b/grpcutil/target.go
@@ -28,7 +28,8 @@ import (
 	"strings"
 )
 
-func parseTarget(target string) (string, string, error) {
+// ParseTarget gRPCエンドポイントアドレス文字列を受け取り、スキーマ/エンドポイントをパースして返す
+func ParseTarget(target string) (string, string, error) {
 	if !strings.HasPrefix(target, "unix:") && !strings.HasPrefix(target, "unix-abstract:") {
 		target = "tcp:" + target
 	}


### PR DESCRIPTION
closes #237 

inputsでの`--dest`フラグを省略した場合、以下の値の中から有効な値(ファイル有無での判定)を探して返すようにする。

- `unix:autoscaler.sock`
- `unix:/var/run/autoscaler.sock`
- `unix:/var/run/autoscaler/autoscaler.sock`

上から順にファイルの存在確認が行われ、最初に見つけたものを返す。

また、この処理のために`grpcuril`のアドレスパース処理をパッケージ外に公開するように修正。