### PR TITLE
e2e: added --dest flag to inputs

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -53,7 +53,7 @@ const (
 
 var (
 	coreCmd    = exec.Command("autoscaler", "server", "start")
-	inputCmd   = exec.Command("autoscaler", "inputs", "grafana", "--addr", "127.0.0.1:8080")
+	inputCmd   = exec.Command("autoscaler", "inputs", "grafana", "--addr", "127.0.0.1:8080", "--dest", "unix:autoscaler.sock")
 	refreshCmd = exec.Command("terraform", "apply", "-refresh-only", "-auto-approve")
 	outputs    []string
 	mu         sync.Mutex


### PR DESCRIPTION
from #262 

#260 によるe2eエラーへの対応
`--dest`を明示することで #262 の問題を回避する。