### PR TITLE
inputs: fixed validation for --dest

### DIFF
--- a/commands/flags/destination.go
+++ b/commands/flags/destination.go
@@ -47,7 +47,7 @@ func ValidateDestinationFlags(*cobra.Command, []string) error {
 	if err := validate.Struct(destination); err != nil {
 		return err
 	}
-	if defaultDestination() == "" {
+	if destination.Destination == "" && defaultDestination() == "" {
 		return fmt.Errorf(
 			"--dest: Core's socket file is not found in [%s]",
 			strings.Join(defaults.CoreSocketAddrCandidates, ", "),


### PR DESCRIPTION
#260 で実装されたバリデーションにおいて、--destが明示された場合でもデフォルト値でのバリデーションが動いてしまう問題を修正