### PR TITLE
Add startup log

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -50,11 +50,17 @@ func newCoreInstance(addr string, c *Config, logger *log.Logger) (*Core, error) 
 
 // LoadAndValidate 指定のファイルパスからコンフィグを読み込み、バリデーションを行う
 func LoadAndValidate(ctx context.Context, configPath string, logger *log.Logger) (*Config, error) {
+	if err := logger.Debug("message", "loading config", "config", configPath); err != nil {
+		return nil, err
+	}
 	config, err := NewConfigFromPath(configPath)
 	if err != nil {
 		return nil, err
 	}
 
+	if err := logger.Debug("message", "validating config"); err != nil {
+		return nil, err
+	}
 	if err := config.Validate(ctx); err != nil {
 		return nil, err
 	}
@@ -63,6 +69,9 @@ func LoadAndValidate(ctx context.Context, configPath string, logger *log.Logger)
 
 // Start 指定のファイルパスからコンフィグを読み込み、gRPCサーバとしてリッスンを開始する
 func Start(ctx context.Context, addr, configPath string, logger *log.Logger) error {
+	if err := logger.Info("message", "starting..."); err != nil {
+		return err
+	}
 	instance, err := newInstanceFromConfig(ctx, addr, configPath, logger)
 	if err != nil {
 		return err
@@ -139,7 +148,7 @@ func (c *Core) run(ctx context.Context) error {
 	}
 
 	go func() {
-		if err := c.logger.Info("message", "autoscaler core started", "address", listener.Addr().String()); err != nil {
+		if err := c.logger.Info("message", "started", "address", listener.Addr().String()); err != nil {
 			errCh <- err
 		}
 		if err := server.Serve(listener); err != nil {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	coreReadyMarker        = `message="autoscaler core started" address=autoscaler.sock`
+	coreReadyMarker        = `message="started" address=autoscaler.sock`
 	inputsReadyMarker      = `message=started address=127.0.0.1:8080`
 	upJobDoneMarker        = `request=Up source=default resource=server status=JOB_DONE`
 	downJobDoneMarker      = `request=Down source=default resource=server status=JOB_DONE`


### PR DESCRIPTION
closes #249

Coreを起動してからリッスンを開始するまでの状況通知のために起動直後にメッセージを表示する。