### PR TITLE
NameOrSelector: Allow unknown fields when unmarshalling YAML

### DIFF
--- a/core/definition_types.go
+++ b/core/definition_types.go
@@ -31,7 +31,8 @@ type NameOrSelector struct {
 func (v *NameOrSelector) UnmarshalYAML(data []byte) error {
 	// セレクタとしてUnmarshalしてみてエラーだったら文字列と見なす
 	var selector ResourceSelector
-	if err := yaml.UnmarshalWithOptions(data, &selector, yaml.Strict()); err != nil {
+	err := yaml.UnmarshalWithOptions(data, &selector, yaml.DisallowDuplicateKey())
+	if err != nil || selector.isEmpty() {
 		selector = ResourceSelector{
 			Names: []string{string(data)},
 		}

--- a/core/definition_types_test.go
+++ b/core/definition_types_test.go
@@ -45,6 +45,14 @@ func TestNameOrSelector_UnmarshalYAML(t *testing.T) {
 			data: []byte(`names: ["foobar1", "foobar2"]`),
 			want: NameOrSelector{ResourceSelector{Names: []string{"foobar1", "foobar2"}}},
 		},
+		{
+			name: "with unknown fields",
+			data: []byte(`
+names: ["foobar1", "foobar2"]
+zones: ["is1a"] # unknown field
+`),
+			want: NameOrSelector{ResourceSelector{Names: []string{"foobar1", "foobar2"}}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/core/resource_selector.go
+++ b/core/resource_selector.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/sacloud/autoscaler/validate"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -70,6 +71,10 @@ func (rs *ResourceSelector) String() string {
 		return fmt.Sprintf("ID: %s, Names: %s, Tags: %s", rs.ID, rs.Names, rs.Tags)
 	}
 	return ""
+}
+
+func (rs *ResourceSelector) isEmpty() bool {
+	return rs.ID.IsEmpty() && strings.Join(rs.Tags, "") == "" && strings.Join(rs.Names, "") == ""
 }
 
 func (rs *ResourceSelector) findCondition() *sacloud.FindCondition {

--- a/core/resource_selector_test.go
+++ b/core/resource_selector_test.go
@@ -159,3 +159,59 @@ func TestResourceSelector_findCondition(t *testing.T) {
 		})
 	}
 }
+
+func TestResourceSelector_isEmpty(t *testing.T) {
+	type fields struct {
+		ID    types.ID
+		Tags  []string
+		Names []string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name:   "empty",
+			fields: fields{},
+			want:   true,
+		},
+		{
+			name:   "with empty Names",
+			fields: fields{Names: []string{""}},
+			want:   true,
+		},
+		{
+			name:   "with empty Tags",
+			fields: fields{Tags: []string{""}},
+			want:   true,
+		},
+		{
+			name:   "with ID",
+			fields: fields{ID: types.ID(1)},
+			want:   false,
+		},
+		{
+			name:   "with Names",
+			fields: fields{Names: []string{"names"}},
+			want:   false,
+		},
+		{
+			name:   "with Tags",
+			fields: fields{Tags: []string{"tags"}},
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rs := &ResourceSelector{
+				ID:    tt.fields.ID,
+				Tags:  tt.fields.Tags,
+				Names: tt.fields.Names,
+			}
+			if got := rs.isEmpty(); got != tt.want {
+				t.Errorf("isEmpty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#271 の準備

現在のMultiZoneSelectorは以下のように定義されている。

```go
type MultiZoneSelector struct {
	*ResourceSelector `yaml:",inline" validate:"required"`
	Zones             []string `yaml:"zones" validate:"required,zones"`
}
```

#271 対応でResourceSelectorをNameOrSelectorに置き換えた場合、NameOrSelectorのUnmarshalYAMLには以下のような値が渡される。

```yaml
names: ["a"]
zones: ["is1a"]
```

NameOrSelectorではオプションとして`yaml.Strict()`を指定しており、未知のフィールドがある場合はエラーとしている。
これを緩和し、未知のフィールドを受け入れるようにすることで #271 対応が行えるようにする。

