### PR TITLE
Check for the existence of default Core socket files at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,6 @@ test:
 	go test $(TESTARGS) -v ./...
 
 .PHONY: e2e-test
-
 e2e-test:
 	docker run -it --rm \
 	    -v $$(PWD):/work \
@@ -81,6 +80,10 @@ e2e-test:
 	    -e SAKURACLOUD_ACCESS_TOKEN_SECRET \
 	    -e SKIP_CLEANUP \
 	    ghcr.io/sacloud/autoscaler:e2e sh -c "./run.sh"
+
+.PHONY: e2e-image
+e2e-image:
+	docker build -t ghcr.io/sacloud/autoscaler:e2e -f e2e/Dockerfile .
 
 .PHONY: lint
 lint:

--- a/commands/flags/destination.go
+++ b/commands/flags/destination.go
@@ -16,11 +16,9 @@ package flags
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/sacloud/autoscaler/defaults"
-	"github.com/sacloud/autoscaler/grpcutil"
 	"github.com/sacloud/autoscaler/validate"
 	"github.com/spf13/cobra"
 )
@@ -44,34 +42,9 @@ func SetDestinationFlag(cmd *cobra.Command) {
 }
 
 func ValidateDestinationFlags(*cobra.Command, []string) error {
-	if err := validate.Struct(destination); err != nil {
-		return err
-	}
-	if destination.Destination == "" && defaultDestination() == "" {
-		return fmt.Errorf(
-			"--dest: Core's socket file is not found in [%s]",
-			strings.Join(defaults.CoreSocketAddrCandidates, ", "),
-		)
-	}
-	return nil
+	return validate.Struct(destination)
 }
 
 func Destination() string {
-	if destination.Destination != "" {
-		return destination.Destination
-	}
-	return defaultDestination()
-}
-
-func defaultDestination() string {
-	for _, dest := range defaults.CoreSocketAddrCandidates {
-		_, endpoint, err := grpcutil.ParseTarget(dest)
-		if err != nil {
-			panic(err) // defaultsでの定義誤り
-		}
-		if _, err := os.Stat(endpoint); err == nil {
-			return dest
-		}
-	}
-	return ""
+	return destination.Destination
 }

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.16 AS builder
+FROM golang:1.17 AS builder
 MAINTAINER Usacloud Authors <sacloud.users@gmail.com>
 
 # Install dependencies

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -53,7 +53,7 @@ const (
 
 var (
 	coreCmd    = exec.Command("autoscaler", "server", "start")
-	inputCmd   = exec.Command("autoscaler", "inputs", "grafana", "--addr", "127.0.0.1:8080", "--dest", "unix:autoscaler.sock")
+	inputCmd   = exec.Command("autoscaler", "inputs", "grafana", "--addr", "127.0.0.1:8080")
 	refreshCmd = exec.Command("terraform", "apply", "-refresh-only", "-auto-approve")
 	outputs    []string
 	mu         sync.Mutex

--- a/grpcutil/dial_test.go
+++ b/grpcutil/dial_test.go
@@ -1,0 +1,57 @@
+// Copyright 2021-2022 The sacloud/autoscaler Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcutil
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/sacloud/autoscaler/defaults"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDialContext(t *testing.T) {
+	tests := []struct {
+		name string
+		opt  *DialOption
+		err  error
+	}{
+		{
+			name: "empty destination",
+			opt: &DialOption{
+				Destination: "",
+			},
+			err: fmt.Errorf(
+				"default socket file not found in [%s]",
+				strings.Join(defaults.CoreSocketAddrCandidates, ", "),
+			),
+		},
+		{
+			name: "non-empty destination",
+			opt: &DialOption{
+				Destination: "unix:invalid.sock", // この段階ではエラーにしない
+			},
+			err: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := DialContext(context.Background(), tt.opt)
+			require.EqualValues(t, tt.err, err)
+		})
+	}
+}

--- a/grpcutil/server.go
+++ b/grpcutil/server.go
@@ -32,7 +32,7 @@ type ListenerOption struct {
 
 // Server 指定のオプションでリッスン構成をした後でリッスンし、*grpc.Serverとクリーンアップ用のfuncを返す
 func Server(opt *ListenerOption) (*grpc.Server, net.Listener, func(), error) {
-	schema, endpoint, err := ParseTarget(opt.Address)
+	schema, endpoint, err := parseTarget(opt.Address)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("ParseTarget failed: %s", err)
 	}

--- a/grpcutil/target.go
+++ b/grpcutil/target.go
@@ -28,8 +28,8 @@ import (
 	"strings"
 )
 
-// ParseTarget gRPCエンドポイントアドレス文字列を受け取り、スキーマ/エンドポイントをパースして返す
-func ParseTarget(target string) (string, string, error) {
+// parseTarget gRPCエンドポイントアドレス文字列を受け取り、スキーマ/エンドポイントをパースして返す
+func parseTarget(target string) (string, string, error) {
 	if !strings.HasPrefix(target, "unix:") && !strings.HasPrefix(target, "unix-abstract:") {
 		target = "tcp:" + target
 	}


### PR DESCRIPTION
closes #262 

#260 で追加されたデフォルトのCoreソケットファイルについて、ファイルの存在確認を実行時に行うように変更。
変更に伴い公開不要になったfuncの修正やフラグ指定の修正を含む。