### PR TITLE
Make context.Context aware in YAML handling

### DIFF
--- a/config/string_or_filepath.go
+++ b/config/string_or_filepath.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"context"
 	"os"
 
 	"github.com/goccy/go-yaml"
@@ -41,7 +42,7 @@ func NewStringOrFilePath(s string) (*StringOrFilePath, error) {
 	}, nil
 }
 
-func (v *StringOrFilePath) UnmarshalYAML(data []byte) error {
+func (v *StringOrFilePath) UnmarshalYAML(ctx context.Context, data []byte) error {
 	var s string
 	if err := yaml.Unmarshal(data, &s); err != nil {
 		return err

--- a/core/config.go
+++ b/core/config.go
@@ -42,7 +42,7 @@ type Config struct {
 }
 
 // NewConfigFromPath 指定のファイルパスからコンフィギュレーションを読み取ってConfigを作成する
-func NewConfigFromPath(filePath string) (*Config, error) {
+func NewConfigFromPath(ctx context.Context, filePath string) (*Config, error) {
 	reader, err := os.Open(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("opening configuration file failed: %s error: %s", filePath, err)
@@ -50,19 +50,19 @@ func NewConfigFromPath(filePath string) (*Config, error) {
 	defer reader.Close()
 
 	c := &Config{}
-	if err := c.load(reader); err != nil {
+	if err := c.load(ctx, reader); err != nil {
 		return nil, err
 	}
 
 	return c, nil
 }
 
-func (c *Config) load(reader io.Reader) error {
+func (c *Config) load(ctx context.Context, reader io.Reader) error {
 	data, err := io.ReadAll(reader)
 	if err != nil {
 		return fmt.Errorf("loading configuration failed: %s", err)
 	}
-	if err := yaml.UnmarshalWithOptions(data, c, yaml.Strict()); err != nil {
+	if err := yaml.UnmarshalWithContext(ctx, data, c, yaml.Strict()); err != nil {
 		return fmt.Errorf(yaml.FormatError(err, false, true))
 	}
 

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"testing"
 
@@ -147,7 +148,7 @@ autoscaler:
 				AutoScaler:     tt.fields.AutoScaler,
 			}
 			c := &Config{}
-			if err := c.load(tt.args.reader); (err != nil) != tt.wantErr {
+			if err := c.load(context.Background(), tt.args.reader); (err != nil) != tt.wantErr {
 				t.Errorf("Load() error = %v, wantErr %v", err, tt.wantErr)
 			}
 

--- a/core/core.go
+++ b/core/core.go
@@ -53,7 +53,7 @@ func LoadAndValidate(ctx context.Context, configPath string, logger *log.Logger)
 	if err := logger.Debug("message", "loading config", "config", configPath); err != nil {
 		return nil, err
 	}
-	config, err := NewConfigFromPath(configPath)
+	config, err := NewConfigFromPath(ctx, configPath)
 	if err != nil {
 		return nil, err
 	}

--- a/core/resource_definitions_marshal.go
+++ b/core/resource_definitions_marshal.go
@@ -15,12 +15,13 @@
 package core
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/goccy/go-yaml"
 )
 
-func (rds *ResourceDefinitions) UnmarshalYAML(data []byte) error {
+func (rds *ResourceDefinitions) UnmarshalYAML(ctx context.Context, data []byte) error {
 	var rawResources []interface{}
 	if err := yaml.UnmarshalWithOptions(data, &rawResources, yaml.Strict()); err != nil {
 		return err

--- a/core/resource_selector.go
+++ b/core/resource_selector.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/goccy/go-yaml"
@@ -105,7 +106,7 @@ type NameOrSelector struct {
 	ResourceSelector
 }
 
-func (v *NameOrSelector) UnmarshalYAML(data []byte) error {
+func (v *NameOrSelector) UnmarshalYAML(ctx context.Context, data []byte) error {
 	// セレクタとしてUnmarshalしてみてエラーだったら文字列と見なす
 	var selector ResourceSelector
 	if err := yaml.UnmarshalWithOptions(data, &selector, yaml.Strict()); err != nil {

--- a/core/server_group_instance_template.go
+++ b/core/server_group_instance_template.go
@@ -339,7 +339,7 @@ type ServerGroupNICUpstream struct {
 	selector *ResourceSelector
 }
 
-func (s *ServerGroupNICUpstream) UnmarshalYAML(data []byte) error {
+func (s *ServerGroupNICUpstream) UnmarshalYAML(ctx context.Context, data []byte) error {
 	if string(data) == "shared" {
 		*s = ServerGroupNICUpstream{raw: data, shared: true}
 		return nil


### PR DESCRIPTION
#274 実装の準備

`yaml.Unmarshal()`時にパラメータにより処理を分岐させるために、context.Contextでパラメータを渡したい。
このために各所での`yaml.BytesUnmarshaler`の実装を`yaml.BytesUnmarshalerContext`に修正する。

Note: #274 の実装のためにはグローバルにフラグを持つ方法も考えたが、現在の実装としてcore.Coreのインスタンスが各種設定を保持しており、以外に状態を持たせたくなかった。このPRによりcore.Coreに設定を保持させた上でcore.Coreがcontext.Contextを差し替えることで設定を受け渡していく方法が取れるようになる。