### PR TITLE
Fix .dockerignore - includes e2e/ dir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .env
 .mailmap
-e2e/
 .git
 bin/
+**/.terraform*
+**/terraform.tfstate*


### PR DESCRIPTION
CIサーバ上などでdockerを用いてテストする場合に必要なファイルが見つからないエラーとなる問題を修正