### PR TITLE
Simplify CLI subcommands

### DIFF
--- a/commands/core/core.go
+++ b/commands/core/core.go
@@ -28,6 +28,11 @@ var Command = &cobra.Command{
 	Aliases:       []string{"server"},
 	Short:         "A set of sub commands to manage autoscaler's core server",
 	SilenceErrors: true,
+
+	// Note: 互換性維持用(since v0.5)
+	// coreのサブコマンド群はroot直下に配置するが、互換性維持のためcoreサブコマンド配下にも配置する。
+	// このときにcoreサブコマンド自体を非表示にするようにHiddenを設定しておく
+	Hidden: true,
 }
 
 var subCommands = []*cobra.Command{
@@ -39,5 +44,10 @@ var subCommands = []*cobra.Command{
 }
 
 func init() {
-	Command.AddCommand(subCommands...)
+	AddSubCommandsTo(Command)
+}
+
+// AddSubCommandsTo 指定のコマンドに対しサブコマンドを登録する
+func AddSubCommandsTo(cmd *cobra.Command) {
+	cmd.AddCommand(subCommands...)
 }

--- a/commands/core/core.go
+++ b/commands/core/core.go
@@ -16,7 +16,6 @@ package core
 
 import (
 	"github.com/sacloud/autoscaler/commands/core/example"
-	"github.com/sacloud/autoscaler/commands/core/handlers"
 	"github.com/sacloud/autoscaler/commands/core/resources"
 	"github.com/sacloud/autoscaler/commands/core/start"
 	"github.com/sacloud/autoscaler/commands/core/validate"
@@ -29,7 +28,7 @@ var Command = &cobra.Command{
 	Short:         "A set of sub commands to manage autoscaler's core server",
 	SilenceErrors: true,
 
-	// Note: 互換性維持用(since v0.5)
+	// Memo: 互換性維持用(since v0.5) v1.0リリース時に除去する
 	// coreのサブコマンド群はroot直下に配置するが、互換性維持のためcoreサブコマンド配下にも配置する。
 	// このときにcoreサブコマンド自体を非表示にするようにHiddenを設定しておく
 	Hidden: true,
@@ -38,7 +37,6 @@ var Command = &cobra.Command{
 var subCommands = []*cobra.Command{
 	example.Command,
 	start.Command,
-	handlers.Command,
 	validate.Command,
 	resources.Command,
 }

--- a/commands/handlers/builtins/cmd.go
+++ b/commands/handlers/builtins/cmd.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package handlers
+package builtins
 
 import (
 	"fmt"
@@ -22,7 +22,7 @@ import (
 )
 
 var Command = &cobra.Command{
-	Use:   "handlers [flags]...",
+	Use:   "list-builtins [flags]...",
 	Short: "list builtin handlers",
 	RunE:  run,
 }

--- a/commands/handlers/handlers.go
+++ b/commands/handlers/handlers.go
@@ -15,6 +15,7 @@
 package handlers
 
 import (
+	"github.com/sacloud/autoscaler/commands/handlers/builtins"
 	"github.com/sacloud/autoscaler/commands/handlers/localexec"
 	"github.com/spf13/cobra"
 )
@@ -26,6 +27,7 @@ var Command = &cobra.Command{
 }
 
 var subCommands = []*cobra.Command{
+	builtins.Command,
 	localexec.Command,
 }
 

--- a/commands/root.go
+++ b/commands/root.go
@@ -39,7 +39,7 @@ var rootCmd = &cobra.Command{
 var subCommands = []*cobra.Command{
 	completion.Command,
 	inputs.Command,
-	core.Command,
+	core.Command, // Memo: 互換性維持用(since: v0.5) v1.0リリース時に除去する
 	cmdVersion.Command,
 	handlers.Command,
 }
@@ -48,7 +48,7 @@ func init() {
 	flags.SetLogFlags(rootCmd)
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
 	rootCmd.AddCommand(subCommands...)
-	// coreコマンドをrootCmd直下にも追加
+	// coreコマンドをrootCmd直下に追加
 	core.AddSubCommandsTo(rootCmd)
 }
 

--- a/commands/root.go
+++ b/commands/root.go
@@ -48,6 +48,8 @@ func init() {
 	flags.SetLogFlags(rootCmd)
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
 	rootCmd.AddCommand(subCommands...)
+	// coreコマンドをrootCmd直下にも追加
+	core.AddSubCommandsTo(rootCmd)
 }
 
 func Execute() {


### PR DESCRIPTION
closes #275

- コマンド体系を見直し、従来は`core`サブコマンド配下にあったサブコマンド群をroot直下に移動する。
  互換性維持のため従来のサブコマンド群も利用可能(`core handlers`を除く)
- `core handlers`を`handlers list-builtins`に移動&リネーム

`core handlers`はこれまでのバージョンと互換性のない変更となるが、利用頻度は低いと思われるため許容する。

変更後のコマンド体系:
```bash
$ autoscaler -h
autoscaler is a tool for managing the scale of resources on SAKURA cloud

Usage:
  autoscaler [command]

Available Commands:
  completion  Generate completion script
  example     show configuration example
  handlers    A set of sub commands to manage autoscaler's external handlers
  help        Help about any command
  inputs      A set of sub commands to manage autoscaler's inputs
  resources   list target resources
  start       start autoscaler's core server
  validate    validate autoscaler's core configuration
  version     show version

Flags:
  -h, --help                help for autoscaler
      --log-format string   Format of logging to be output. options: [ logfmt | json ] (default "logfmt")
      --log-level string    Level of logging to be output. options: [ error | warn | info | debug ] (default "info")
  -v, --version             version for autoscaler

Use "autoscaler [command] --help" for more information about a command.
```

```bash
autoscaler handlers -h
A set of sub commands to manage autoscaler's external handlers

Usage:
  autoscaler handlers [command]

Available Commands:
  list-builtins list builtin handlers
  local-exec    Handler for executing a shell script

Flags:
  -h, --help   help for handlers

Global Flags:
      --log-format string   Format of logging to be output. options: [ logfmt | json ] (default "logfmt")
      --log-level string    Level of logging to be output. options: [ error | warn | info | debug ] (default "info")

Use "autoscaler handlers [command] --help" for more information about a command.
```

coreサブコマンドは非表示だが利用は可能。ただしv1.0リリースまでには除去する予定。

```bash
$ autoscaler core -h
autoscaler core -h
A set of sub commands to manage autoscaler's core server

Usage:
  autoscaler core [command]

Aliases:
  core, server

Available Commands:
  example     show configuration example
  resources   list target resources
  start       start autoscaler's core server
  validate    validate autoscaler's core configuration

Flags:
  -h, --help   help for core

Global Flags:
      --log-format string   Format of logging to be output. options: [ logfmt | json ] (default "logfmt")
      --log-level string    Level of logging to be output. options: [ error | warn | info | debug ] (default "info")

Use "autoscaler core [command] --help" for more information about a command.
```