### PR TITLE
e2e: added using old command senario

### DIFF
--- a/e2e/horizontal_scaling/e2e_test.go
+++ b/e2e/horizontal_scaling/e2e_test.go
@@ -19,7 +19,6 @@ package horizontal_scaling
 
 import (
 	"context"
-	_ "embed"
 	"fmt"
 	"log"
 	"os/exec"
@@ -41,7 +40,7 @@ const (
 )
 
 var (
-	coreCmd       = exec.Command("autoscaler", "server", "start")
+	coreCmd       = exec.Command("autoscaler", "start")
 	upCmd         = exec.Command("autoscaler", "inputs", "direct", "--resource-name", "autoscaler-e2e-horizontal-scaling", "up")
 	upToMediumCmd = exec.Command("autoscaler", "inputs", "direct", "--resource-name", "autoscaler-e2e-horizontal-scaling", "--desired-state-name", "medium", "up")
 	downCmd       = exec.Command("autoscaler", "inputs", "direct", "--resource-name", "autoscaler-e2e-horizontal-scaling", "down")

--- a/e2e/old_core_command/e2e.tf
+++ b/e2e/old_core_command/e2e.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    sakuracloud = {
+      source  = "sacloud/sakuracloud"
+      version = "2.14.2"
+    }
+  }
+}
+
+provider "sakuracloud" {
+  zone = "is1a"
+}
+
+resource "sakuracloud_proxylb" "autoscaler-e2e-test" {
+  name    = "autoscaler-e2e-old-core-command"
+  plan    = 100
+  timeout = 10
+  region  = "is1"
+
+  health_check {
+    protocol   = "http"
+    delay_loop = 10
+    path       = "/"
+  }
+
+  bind_port {
+    proxy_mode = "http"
+    port       = 80
+    response_header {
+      header = "Cache-Control"
+      value  = "public, max-age=10"
+    }
+  }
+}

--- a/e2e/old_core_command/e2e_test.go
+++ b/e2e/old_core_command/e2e_test.go
@@ -1,0 +1,99 @@
+// Copyright 2021-2022 The sacloud/autoscaler Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e
+// +build e2e
+
+package old_core_command
+
+import (
+	"log"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/sacloud/autoscaler/e2e"
+)
+
+const (
+	coreReadyMarker = `message=started address=autoscaler.sock`
+)
+
+var (
+	coreCmd = exec.Command("autoscaler", "core", "start")
+	output  = &e2e.Output{}
+)
+
+func TestMain(m *testing.M) {
+	defer teardown()
+	setup()
+
+	m.Run()
+}
+
+func TestE2E_OldCoreCommand(t *testing.T) {
+	/**************************************************************************
+	 * Step 1: 古いコマンド(autoscaler core start)でのCoreの起動確認
+	 *************************************************************************/
+	log.Println("step0: setup")
+	coreOutputs, err := coreCmd.StderrPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := coreCmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	go output.CollectOutputs("[Core]", coreOutputs)
+	if err := output.WaitOutput(coreReadyMarker, 3*time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	// grpc-health-probeでSERVINGになっていることを確認
+	out, err := exec.Command("grpc-health-probe", "-addr", "unix:autoscaler.sock").CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "status: SERVING") {
+		t.Fatalf("grpc-health-prove: unexpected response: %s", string(out))
+	}
+
+	defer output.OutputLogs()
+}
+
+func setup() {
+	if err := e2e.TerraformInit(); err != nil {
+		log.Fatal(err)
+	}
+	if err := e2e.TerraformApply(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func teardown() {
+	if coreCmd.Process != nil {
+		if err := coreCmd.Process.Signal(syscall.SIGINT); err != nil {
+			log.Println(err)
+		}
+		if err := coreCmd.Wait(); err != nil {
+			log.Println(err)
+		}
+	}
+
+	if err := e2e.TerraformDestroy(); err != nil {
+		log.Println(err)
+	}
+}

--- a/e2e/vertical_scaling/e2e_test.go
+++ b/e2e/vertical_scaling/e2e_test.go
@@ -46,7 +46,7 @@ const (
 )
 
 var (
-	coreCmd  = exec.Command("autoscaler", "server", "start")
+	coreCmd  = exec.Command("autoscaler", "start")
 	inputCmd = exec.Command("autoscaler", "inputs", "grafana", "--addr", "127.0.0.1:8080")
 
 	proxyLBReadyTimeout = 5 * time.Minute


### PR DESCRIPTION
#298 のフォロー

- 既存のe2eテストを新コマンド体系に移行
- 旧コマンド体系向けのシナリオを追加