### PR TITLE
fakeドライバー向けの一時ファイルを無視リストに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ autoscaler.yaml
 **/terraform.tfstate*
 
 work/
+fake-store.json


### PR DESCRIPTION
#320 の補完

fakeドライバーが利用するJSONストアのファイルがテストのたびに生成されるため無視リストに追加しておく