### PR TITLE
e2e: e2e/old_core_command/autoscaler.yamlをgit管理下に

### DIFF
--- a/e2e/old_core_command/autoscaler.yaml
+++ b/e2e/old_core_command/autoscaler.yaml
@@ -1,0 +1,7 @@
+resources:
+  - type: ELB
+    name: "elb"
+    selector:
+      names: ["autoscaler-e2e-old-core-command"]
+autoscaler:
+  cooldown: 5


### PR DESCRIPTION
closes #322 

autoscaler.yamlは.gitignoreに書かれているため-fを指定してgit addしている。