### PR TITLE
バージョン定義文字列をN.N.N形式に修正

### DIFF
--- a/commands/root.go
+++ b/commands/root.go
@@ -33,7 +33,7 @@ var rootCmd = &cobra.Command{
 	PersistentPreRunE: flags.ValidateLogFlags,
 	SilenceUsage:      true,
 	SilenceErrors:     false,
-	Version:           version.Version,
+	Version:           "v" + version.Version,
 }
 
 var subCommands = []*cobra.Command{

--- a/commands/version/version.go
+++ b/commands/version/version.go
@@ -31,7 +31,7 @@ var Command = &cobra.Command{
 	Use:   "version",
 	Short: "show version",
 	RunE: func(*cobra.Command, []string) error {
-		v := version.Version
+		v := "v" + version.Version
 		if all {
 			v = version.FullVersion()
 		}

--- a/core/sakuracloud.go
+++ b/core/sakuracloud.go
@@ -59,7 +59,7 @@ func (sc *SakuraCloud) APIClient() iaas.APICaller {
 				AccessTokenSecret: sc.Secret,
 				HttpClient:        &http.Client{},
 				UserAgent: fmt.Sprintf(
-					"sacloud/autoscaler/%s (%s/%s; +https://github.com/sacloud/autoscaler) %s",
+					"sacloud/autoscaler/v%s (%s/%s; +https://github.com/sacloud/autoscaler) %s",
 					version.Version,
 					runtime.GOOS,
 					runtime.GOARCH,

--- a/e2e/sacloud.go
+++ b/e2e/sacloud.go
@@ -31,7 +31,7 @@ var SacloudAPICaller = api.NewCallerWithOptions(&api.CallerOptions{
 		AccessToken:       os.Getenv("SAKURACLOUD_ACCESS_TOKEN"),
 		AccessTokenSecret: os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET"),
 		UserAgent: fmt.Sprintf(
-			"sacloud/autoscaler/v%s/e2e-test (%s/%s; +https://github.com/sacloud/autoscaler) %s",
+			"sacloud/autoscaler@v%s:e2e-test (%s/%s; +https://github.com/sacloud/autoscaler) %s",
 			version.Version,
 			runtime.GOOS,
 			runtime.GOARCH,

--- a/version/version.go
+++ b/version/version.go
@@ -21,12 +21,12 @@ import (
 
 var (
 	// Version app version
-	Version = "v0.5.1"
+	Version = "0.5.1"
 	// Revision git commit short commithash
 	Revision = "xxxxxx" // set on build time
 )
 
 // FullVersion return full version text
 func FullVersion() string {
-	return fmt.Sprintf("%s %s/%s, build %s", Version, runtime.GOOS, runtime.GOARCH, Revision)
+	return fmt.Sprintf("v%s %s/%s, build %s", Version, runtime.GOOS, runtime.GOARCH, Revision)
 }


### PR DESCRIPTION
従来はv+N.N.N形式にしていたが、プレフィックスは利用する側でつける方向で統一する