### PR TITLE
リソース定義が1つだけの場合にnameを省略可能に

### DIFF
--- a/core/config_test.go
+++ b/core/config_test.go
@@ -62,7 +62,6 @@ func TestConfig_Load(t *testing.T) {
 				Resources: ResourceDefinitions{
 					&ResourceDefServer{
 						ResourceDefBase: &ResourceDefBase{
-							DefName:  "test-name",
 							TypeName: "Server",
 						},
 						Selector: &MultiZoneSelector{
@@ -110,7 +109,6 @@ handlers:
     endpoint: "unix:autoscaler-handlers-fake.sock"
 resources:
   - type: Server
-    name: "test-name"
     selector:
       names: ["test-name"]
       tags: ["test-tag"]

--- a/core/resource_definition.go
+++ b/core/resource_definition.go
@@ -41,7 +41,7 @@ type ResourceDefinition interface {
 // Resourceの実装に埋め込む場合、Compute()でComputedCacheを設定すること
 type ResourceDefBase struct {
 	TypeName string `yaml:"type" validate:"required,oneof=EnhancedLoadBalancer ELB Router Server ServerGroup"`
-	DefName  string `yaml:"name" validate:"required"`
+	DefName  string `yaml:"name"`
 
 	// セットアップのための猶予時間(秒数)
 	// Handleされた後、セットアップの完了を待つためにこの秒数分待つ

--- a/core/resource_definitions.go
+++ b/core/resource_definitions.go
@@ -38,10 +38,17 @@ func (rds *ResourceDefinitions) Validate(ctx context.Context, apiClient iaas.API
 		if errs := r.Validate(ctx, apiClient); len(errs) > 0 {
 			errors = append(errors, errs...)
 		}
-		if _, exist := names[r.Name()]; exist {
-			errors = append(errors, fmt.Errorf("resource name %s is duplicated", r.Name()))
+
+		if len(*rds) > 1 {
+			if r.Name() == "" {
+				errors = append(errors, fmt.Errorf("name is required if the configuration has more than one resource"))
+			}
+			if _, exist := names[r.Name()]; exist {
+				errors = append(errors, fmt.Errorf("resource name %s is duplicated", r.Name()))
+			}
+			names[r.Name()] = struct{}{}
 		}
-		names[r.Name()] = struct{}{}
+
 		return nil
 	}
 

--- a/core/resource_definitions_test.go
+++ b/core/resource_definitions_test.go
@@ -181,6 +181,23 @@ func TestResourceDefinitions_Validate(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "omit resource name",
+			rds: ResourceDefinitions{
+				&stubResourceDef{ResourceDefBase: &ResourceDefBase{TypeName: "ELB"}},
+			},
+			want: nil,
+		},
+		{
+			name: "omit resource name with multiple resources",
+			rds: ResourceDefinitions{
+				&stubResourceDef{ResourceDefBase: &ResourceDefBase{TypeName: "ELB"}},
+				&stubResourceDef{ResourceDefBase: &ResourceDefBase{TypeName: "ELB", DefName: "stub1"}},
+			},
+			want: []error{
+				fmt.Errorf("name is required if the configuration has more than one resource"),
+			},
+		},
+		{
 			name: "duplicated",
 			rds: ResourceDefinitions{
 				&stubResourceDef{ResourceDefBase: &ResourceDefBase{TypeName: "ELB", DefName: "duplicated"}},


### PR DESCRIPTION
コンフィギュレーションでリソース定義をする際、複数のリソースを識別するためにnameを必須としていたが、
リソース定義が1つだけの場合は省略できるようにすることでより簡潔に記載できるようにする。

最小限のコンフィギュレーションの例:

```yaml
resources:
  - type: Server
    selector:
      names: ["example"]
      zones: ["is1a"]
```