### PR TITLE
structレベルのバリデーション後にResourceDefのValidate()を呼ぶ

### DIFF
--- a/core/resource_definitions.go
+++ b/core/resource_definitions.go
@@ -34,9 +34,11 @@ func (rds *ResourceDefinitions) Validate(ctx context.Context, apiClient iaas.API
 	fn := func(r ResourceDefinition) error {
 		if err := validate.Struct(r); err != nil {
 			errors = append(errors, multierror.Prefix(err, fmt.Sprintf("resource=%s", r.Type())))
-		}
-		if errs := r.Validate(ctx, apiClient); len(errs) > 0 {
-			errors = append(errors, errs...)
+		} else {
+			// structレベルでバリデーションが通った場合のみResourceDefのバリデーションを呼ぶ
+			if errs := r.Validate(ctx, apiClient); len(errs) > 0 {
+				errors = append(errors, errs...)
+			}
 		}
 
 		if len(*rds) > 1 {

--- a/core/resource_stub_test.go
+++ b/core/resource_stub_test.go
@@ -23,13 +23,19 @@ import (
 type stubResourceDef struct {
 	*ResourceDefBase
 	computeFunc func(ctx *RequestContext, apiClient iaas.APICaller) (Resources, error)
+
+	Dummy        string `validate:"omitempty,oneof=value1 value2"`
+	validateFunc func(ctx context.Context, apiClient iaas.APICaller) []error
 }
 
 func (d *stubResourceDef) String() string {
 	return "stub"
 }
 
-func (d *stubResourceDef) Validate(_ context.Context, _ iaas.APICaller) []error {
+func (d *stubResourceDef) Validate(ctx context.Context, apiClient iaas.APICaller) []error {
+	if d.validateFunc != nil {
+		return d.validateFunc(ctx, apiClient)
+	}
 	return nil
 }
 


### PR DESCRIPTION
さくらのクラウドAPIコールに不正な値が渡ってしまう問題を修正