### PR TITLE
e2e: setup_grace_periodの追加

### DIFF
--- a/e2e/horizontal_scaling/autoscaler.yaml
+++ b/e2e/horizontal_scaling/autoscaler.yaml
@@ -5,6 +5,8 @@ resources:
     min_size: 0
     max_size: 5
 
+    setup_grace_period: 30
+
     plans:
       - {name: "smallest", size: 0}
       - {name: "medium", size: 3}


### PR DESCRIPTION
closes #330 

`setup_grace_period`を指定することでサーバ起動後の503エラーに対応する