### PR TITLE
サーバグループで意図しないサーバを対象にしてしまう問題への対応

### DIFF
--- a/commands/core/example/example.yaml
+++ b/commands/core/example/example.yaml
@@ -23,8 +23,10 @@ resources:
 
   # サーバ(水平スケール)
   - type: ServerGroup
-    # サーバグループ名、グループ内の各サーバの名前のプレフィックスして利用される(例: server-group-001)
     name: "server-group"
+
+    # グループ内の各サーバの名前のプレフィックス
+    server_name_prefix: "server-group"
     zone: "is1a"
 
     min_size: 5   # 最小インスタンス数


### PR DESCRIPTION
- サーバグループにserver_name_prefixを導入
- server_name_prefixとサーバ名を前方一致で比較

従来はnameがプレフィックスとしての役割を兼ねていたのをserver_name_prefixで指定するように変更する。
基本的にnameはコンフィグで定義された複数のリソースから処理対象を特定するためのものとする。

互換性のためにserver_name_prefixが指定されなかった場合は従来通りnameを利用する。
同時にバリデーションも変更しnameとserver_name_prefixの両方が指定されなかった場合はエラーとする。

また、従来はクラウド上のサーバ名とnameが部分一致するサーバをサーバグループの処理対象としていたが、
これを厳格化しnameと前方一致するサーバを対象とするように変更する。