### PR TITLE
ResourceDefBaseで受け入れ可能なTypeの定義が不足していた問題を修正

### DIFF
--- a/core/resource_definition.go
+++ b/core/resource_definition.go
@@ -62,6 +62,12 @@ func (r *ResourceDefBase) Type() ResourceTypes {
 		return ResourceTypeServerGroupInstance
 	case ResourceTypeELB.String(), "ELB":
 		return ResourceTypeELB
+	case ResourceTypeGSLB.String():
+		return ResourceTypeGSLB
+	case ResourceTypeDNS.String():
+		return ResourceTypeDNS
+	case ResourceTypeRouter.String():
+		return ResourceTypeRouter
 	case ResourceTypeLoadBalancer.String():
 		return ResourceTypeLoadBalancer
 	default:

--- a/core/resource_definition_test.go
+++ b/core/resource_definition_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sacloud/autoscaler/defaults"
 	"github.com/sacloud/iaas-api-go/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMultiZoneSelector_Validate(t *testing.T) {
@@ -125,6 +126,72 @@ func TestResourceDefBase_SetupGracePeriod(t *testing.T) {
 			if got := r.SetupGracePeriod(); got != tt.want {
 				t.Errorf("SetupGracePeriod() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestResourceDefBase_Type(t *testing.T) {
+	tests := []struct {
+		typeName string
+		want     ResourceTypes
+		panic    bool
+	}{
+		{
+			typeName: ResourceTypeUnknown.String(),
+			panic:    true,
+		},
+		{
+			typeName: ResourceTypeServer.String(),
+			want:     ResourceTypeServer,
+		},
+		{
+			typeName: ResourceTypeServerGroup.String(),
+			want:     ResourceTypeServerGroup,
+		},
+		{
+			typeName: ResourceTypeServerGroupInstance.String(),
+			want:     ResourceTypeServerGroupInstance,
+		},
+		{
+			typeName: ResourceTypeELB.String(),
+			want:     ResourceTypeELB,
+		},
+		{
+			typeName: "ELB",
+			want:     ResourceTypeELB,
+		},
+		{
+			typeName: ResourceTypeGSLB.String(),
+			want:     ResourceTypeGSLB,
+		},
+		{
+			typeName: ResourceTypeDNS.String(),
+			want:     ResourceTypeDNS,
+		},
+		{
+			typeName: ResourceTypeRouter.String(),
+			want:     ResourceTypeRouter,
+		},
+		{
+			typeName: ResourceTypeLoadBalancer.String(),
+			want:     ResourceTypeLoadBalancer,
+		},
+		{
+			typeName: "unknown-type",
+			panic:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.typeName, func(t *testing.T) {
+			defer func() {
+				err := recover()
+				require.Equal(t, tt.panic, err != nil)
+			}()
+			r := &ResourceDefBase{
+				TypeName: tt.typeName,
+				DefName:  "test-def",
+			}
+			require.Equal(t, r.Type(), tt.want)
 		})
 	}
 }

--- a/core/resource_definitions_marshal.go
+++ b/core/resource_definitions_marshal.go
@@ -68,6 +68,8 @@ func (rds *ResourceDefinitions) unmarshalResourceDefFromMap(data map[string]inte
 
 	var def ResourceDefinition
 	switch typeName {
+	// Note: ここではトップレベルに設定可能なリソースタイプのみ受け付ける
+	//       Parent配下でのみ指定可能なリソースタイプはParentResourceDefで検証される
 	case "Server":
 		v := &ResourceDefServer{}
 		if err := yaml.UnmarshalWithOptions(remarshelded, v, yaml.Strict()); err != nil {


### PR DESCRIPTION
#303 によりResourceDefBaseで受け入れ可能なTypeを除去したが、本来ここではトップレベル/ネストレベル問わず全てのTypeを受け入れるべきなため不足している定義を追加して対応する。