### PR TITLE
crazy-max/ghaction-import-gpg@v5でのパラメータ名変更対応

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,10 +26,10 @@ jobs:
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5
         with:
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          git-user-signingkey: true
-          git-commit-gpgsign: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3


### PR DESCRIPTION
パラメータ名が`-`から`_`を用いるように変更されたことへの対応