### PR TITLE
シグナルハンドリングの改善

### DIFF
--- a/core/resource_definitions.go
+++ b/core/resource_definitions.go
@@ -106,7 +106,10 @@ func (rds *ResourceDefinitions) FilterByResourceName(name string) ResourceDefini
 	return nil
 }
 
-func (rds *ResourceDefinitions) HandleAll(ctx *RequestContext, apiClient iaas.APICaller, handlers Handlers) {
+func (rds *ResourceDefinitions) HandleAll(ctx *RequestContext, apiClient iaas.APICaller, handlers Handlers, cleanup func()) {
+	if cleanup != nil {
+		defer cleanup()
+	}
 	job := ctx.Job()
 	job.SetStatus(request.ScalingJobStatus_JOB_RUNNING)
 	ctx.Logger().Info("status", request.ScalingJobStatus_JOB_RUNNING) // nolint


### PR DESCRIPTION
closes #381 

SIGINTまたはSIGTERMを受け取った際にUp/Downの処理中だった場合には処理が終わるまで待つように修正

Note: このPRでは処理を待つ時間は30分固定。後続PRでコンフィギュレーションでの指定を可能とする。

Note: これらのシグナルを複数回受け取った時の処理は未実装。
このためUp/Downの処理中でも強制的に終了させたい場合はSIGKILLなどを送信する必要がある。