### PR TITLE
シャットダウン猶予時間をコンフィギュレーションで指定可能に

### DIFF
--- a/commands/core/example/example.yaml
+++ b/commands/core/example/example.yaml
@@ -186,6 +186,7 @@ resources:
 ## オートスケーラーの動作設定
 autoscaler:
   cooldown: 600 # ジョブの連続実行を抑止するためのクールダウン期間を秒数で指定。デフォルト: 600(10分)
+  shutdown_grace_period: 600 # SIGINTまたはSIGTERMをを受け取った際の処理完了待ち猶予時間を秒で指定。デフォルト: 600(10分)
 
 #  # CoreのgRPCエンドポイントのTLS設定(省略可)
 #  server_tls_config:

--- a/commands/core/start/cmd.go
+++ b/commands/core/start/cmd.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/sacloud/autoscaler/commands/flags"
 	"github.com/sacloud/autoscaler/core"
@@ -71,8 +70,10 @@ func run(*cobra.Command, []string) error {
 
 	go func() {
 		<-signalCtx.Done()
-		logger.Info("message", "signal received. waiting for shutdown...") // nolint: errcheck
-		if err := coreInstance.Stop(30 * time.Minute); err != nil {        // TODO 後続PRでコンフィグでのタイムアウト秒数指定を可能とする
+		if ctx.Err() != nil {
+			logger.Info("message", "signal received. waiting for shutdown...") // nolint: errcheck
+		}
+		if err := coreInstance.Stop(); err != nil {
 			logger.Error("error", err) // nolint: errcheck
 		}
 		shutdown()

--- a/core/config.go
+++ b/core/config.go
@@ -219,11 +219,12 @@ func (c *Config) ValidateCustomHandler(ctx context.Context, handler *Handler) er
 
 // AutoScalerConfig オートスケーラー自体の動作設定
 type AutoScalerConfig struct {
-	CoolDownSec      int                    `yaml:"cooldown"`           // 同一ジョブの連続実行を防ぐための冷却期間(単位:秒)
-	ServerTLSConfig  *config.TLSStruct      `yaml:"server_tls_config"`  // CoreへのgRPC接続のTLS設定
-	HandlerTLSConfig *config.TLSStruct      `yaml:"handler_tls_config"` // HandlersへのgRPC接続のTLS設定
-	ExporterConfig   *config.ExporterConfig `yaml:"exporter_config"`    // Exporter設定
-	HandlersConfig   *HandlersConfig        `yaml:"handlers_config"`    // ビルトインハンドラーの設定
+	CoolDownSec            int                    `yaml:"cooldown"`              // 同一ジョブの連続実行を防ぐための冷却期間(単位:秒)
+	ShutdownGracePeriodSec int                    `yaml:"shutdown_grace_period"` // SIGINTまたはSIGTERMをを受け取った際の処理完了待ち猶予時間(単位:秒)
+	ServerTLSConfig        *config.TLSStruct      `yaml:"server_tls_config"`     // CoreへのgRPC接続のTLS設定
+	HandlerTLSConfig       *config.TLSStruct      `yaml:"handler_tls_config"`    // HandlersへのgRPC接続のTLS設定
+	ExporterConfig         *config.ExporterConfig `yaml:"exporter_config"`       // Exporter設定
+	HandlersConfig         *HandlersConfig        `yaml:"handlers_config"`       // ビルトインハンドラーの設定
 }
 
 func (c *AutoScalerConfig) Validate(ctx context.Context) []error {
@@ -234,6 +235,14 @@ func (c *AutoScalerConfig) JobCoolDownTime() time.Duration {
 	sec := c.CoolDownSec
 	if sec <= 0 {
 		return defaults.CoolDownTime
+	}
+	return time.Duration(sec) * time.Second
+}
+
+func (c *AutoScalerConfig) ShutdownGracePeriod() time.Duration {
+	sec := c.ShutdownGracePeriodSec
+	if sec <= 0 {
+		return defaults.ShutdownGracePeriod
 	}
 	return time.Duration(sec) * time.Second
 }

--- a/core/core.go
+++ b/core/core.go
@@ -233,7 +233,11 @@ func (c *Core) ResourceName(name string) (string, error) {
 }
 
 // Stop リクエストの新規受付を停止しつつ現在処理中のUp/Downがあれば終わるまでブロックする
-func (c *Core) Stop(timeout time.Duration) error {
+func (c *Core) Stop() error {
+	return c.stop(c.config.AutoScaler.ShutdownGracePeriod())
+}
+
+func (c *Core) stop(timeout time.Duration) error {
 	c.stopping = true
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -237,7 +237,7 @@ func TestCore_Stop(t *testing.T) {
 			}),
 		}
 
-		err := c.Stop(5 * time.Second)
+		err := c.stop(5 * time.Second)
 		require.NoError(t, err)
 		require.True(t, c.stopping)
 	})
@@ -256,7 +256,7 @@ func TestCore_Stop(t *testing.T) {
 			time.Sleep(1 * time.Second)
 			c.setRunningStatus(false)
 		}()
-		err := c.Stop(10 * time.Second)
+		err := c.stop(10 * time.Second)
 		require.NoError(t, err)
 	})
 
@@ -269,7 +269,7 @@ func TestCore_Stop(t *testing.T) {
 			running: true,
 		}
 
-		err := c.Stop(time.Millisecond)
+		err := c.stop(time.Millisecond)
 		require.Error(t, err) // timeout
 	})
 }

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -26,7 +26,8 @@ const (
 	SourceName       = "default"
 	DesiredStateName = "default"
 
-	CoolDownTime = 10 * time.Minute // 同一ジョブの実行制御のための冷却期間
+	CoolDownTime        = 10 * time.Minute // 同一ジョブの実行制御のための冷却期間
+	ShutdownGracePeriod = 10 * time.Minute
 )
 
 var (


### PR DESCRIPTION
#384 の補完

コンフィギュレーションで以下のように指定可能にする。

```yaml
## オートスケーラーの動作設定
autoscaler:
  shutdown_grace_period: 600 # SIGINTまたはSIGTERMをを受け取った際の処理完了待ち猶予時間を秒で指定。デフォルト: 600(10分)

```