### PR TITLE
IDを指定する項目でセレクタを指定可能に

### DIFF
--- a/core/resource_selector_test.go
+++ b/core/resource_selector_test.go
@@ -193,3 +193,41 @@ func TestNameOrSelector_UnmarshalYAML(t *testing.T) {
 		})
 	}
 }
+
+func TestIdOrNameOrSelector_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		want IdOrNameOrSelector
+	}{
+		{
+			name: "empty",
+			data: []byte(``),
+			want: IdOrNameOrSelector{ResourceSelector{}},
+		},
+		{
+			name: "id",
+			data: []byte(`123456789012`),
+			want: IdOrNameOrSelector{ResourceSelector{ID: 123456789012}},
+		},
+		{
+			name: "name",
+			data: []byte(`foobar`),
+			want: IdOrNameOrSelector{ResourceSelector{Names: []string{"foobar"}}},
+		},
+		{
+			name: "selector",
+			data: []byte(`names: ["foobar1", "foobar2"]`),
+			want: IdOrNameOrSelector{ResourceSelector{Names: []string{"foobar1", "foobar2"}}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var v IdOrNameOrSelector
+			if err := yaml.UnmarshalWithOptions(tt.data, &v, yaml.Strict()); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			require.EqualValues(t, tt.want, v)
+		})
+	}
+}

--- a/core/resource_server_group_instance.go
+++ b/core/resource_server_group_instance.go
@@ -195,6 +195,11 @@ func (r *ResourceServerGroupInstance) computeDisks(ctx *RequestContext) ([]*hand
 		if err != nil {
 			return nil, err
 		}
+		iconId, err := tmpl.FindIconID(ctx, r.apiClient)
+		if err != nil {
+			return nil, err
+		}
+
 		disks = append(disks, &handler.ServerGroupInstance_Disk{
 			Id:              "",
 			Zone:            r.zone,
@@ -206,7 +211,7 @@ func (r *ResourceServerGroupInstance) computeDisks(ctx *RequestContext) ([]*hand
 			Name:            tmpl.DiskName(r.server.Name, i),
 			Tags:            tmpl.Tags,
 			Description:     tmpl.Description,
-			IconId:          tmpl.IconID,
+			IconId:          iconId,
 		})
 	}
 	return disks, nil
@@ -254,9 +259,13 @@ func (r *ResourceServerGroupInstance) computeNetworkInterfaces(ctx *RequestConte
 			}
 		}
 
+		packetFilterId, err := tmpl.FindPacketFilterId(ctx, r.apiClient, r.zone)
+		if err != nil {
+			return nil, err
+		}
 		nic := &handler.ServerGroupInstance_NIC{
 			Upstream:       upstream,
-			PacketFilterId: tmpl.PacketFilterID,
+			PacketFilterId: packetFilterId,
 			ExposeInfo:     exposeInfo,
 		}
 

--- a/core/resource_server_group_instance.go
+++ b/core/resource_server_group_instance.go
@@ -155,7 +155,6 @@ func (r *ResourceServerGroupInstance) computeEditParameter(ctx *RequestContext, 
 		EnableDhcp:          tmpl.EnableDHCP,
 		ChangePartitionUuid: tmpl.ChangePartitionUUID,
 		SshKeys:             sshKeys,
-		SshKeyIds:           tmpl.SSHKeyIDs,
 		StartupScripts:      startupScripts, // Note: この段階ではGoテンプレートは未評価のまま渡す。
 
 		// これらは必要に応じてHandlerが設定する

--- a/core/server_group_instance_template.go
+++ b/core/server_group_instance_template.go
@@ -35,9 +35,15 @@ type ServerGroupInstanceTemplate struct {
 	Tags        []string `yaml:"tags" validate:"unique,max=10,dive,max=32"`
 	Description string   `yaml:"description" validate:"max=512"`
 
-	IconID          *IdOrNameOrSelector    `yaml:"icon_id"`
-	CDROMID         *IdOrNameOrSelector    `yaml:"cdrom_id"`
-	PrivateHostID   *IdOrNameOrSelector    `yaml:"private_host_id"`
+	IconId string              `yaml:"icon_id"`
+	Icon   *IdOrNameOrSelector `yaml:"icon"`
+
+	CDROMId string              `yaml:"cdrom_id"`
+	CDROM   *IdOrNameOrSelector `yaml:"cdrom"`
+
+	PrivateHostId string              `yaml:"private_host_id"`
+	PrivateHost   *IdOrNameOrSelector `yaml:"private_host"`
+
 	InterfaceDriver types.EInterfaceDriver `yaml:"interface_driver" validate:"omitempty,oneof=virtio e1000"`
 
 	Plan              *ServerGroupInstancePlan     `yaml:"plan" validate:"required"`
@@ -54,6 +60,15 @@ func (s *ServerGroupInstanceTemplate) Validate(ctx context.Context, apiClient ia
 	}
 
 	errors := &multierror.Error{}
+	if s.IconId != "" && s.Icon != nil {
+		errors = multierror.Append(errors, fmt.Errorf("only one of icon and icon_id can be specified"))
+	}
+	if s.CDROMId != "" && s.CDROM != nil {
+		errors = multierror.Append(errors, fmt.Errorf("only one of cdrom and cdrom_id can be specified"))
+	}
+	if s.PrivateHostId != "" && s.PrivateHost != nil {
+		errors = multierror.Append(errors, fmt.Errorf("only one of private_host and private_host_id can be specified"))
+	}
 	if err := s.Plan.Validate(ctx, apiClient, def.Zone); err != nil {
 		errors = multierror.Append(errors, err)
 	}
@@ -81,8 +96,11 @@ func (s *ServerGroupInstanceTemplate) Validate(ctx context.Context, apiClient ia
 }
 
 func (s *ServerGroupInstanceTemplate) FindIconId(ctx context.Context, apiClient iaas.APICaller) (string, error) {
-	if s.IconID != nil {
-		found, err := iaas.NewIconOp(apiClient).Find(ctx, s.IconID.findCondition())
+	if s.IconId != "" {
+		return s.IconId, nil
+	}
+	if s.Icon != nil {
+		found, err := iaas.NewIconOp(apiClient).Find(ctx, s.Icon.findCondition())
 		if err != nil {
 			return "", err
 		}
@@ -95,8 +113,11 @@ func (s *ServerGroupInstanceTemplate) FindIconId(ctx context.Context, apiClient 
 }
 
 func (s *ServerGroupInstanceTemplate) FindCDROMId(ctx context.Context, apiClient iaas.APICaller, zone string) (string, error) {
-	if s.CDROMID != nil {
-		found, err := iaas.NewCDROMOp(apiClient).Find(ctx, zone, s.CDROMID.findCondition())
+	if s.CDROMId != "" {
+		return s.CDROMId, nil
+	}
+	if s.CDROM != nil {
+		found, err := iaas.NewCDROMOp(apiClient).Find(ctx, zone, s.CDROM.findCondition())
 		if err != nil {
 			return "", err
 		}
@@ -109,8 +130,11 @@ func (s *ServerGroupInstanceTemplate) FindCDROMId(ctx context.Context, apiClient
 }
 
 func (s *ServerGroupInstanceTemplate) FindPrivateHostId(ctx context.Context, apiClient iaas.APICaller, zone string) (string, error) {
-	if s.PrivateHostID != nil {
-		found, err := iaas.NewPrivateHostOp(apiClient).Find(ctx, zone, s.PrivateHostID.findCondition())
+	if s.PrivateHostId != "" {
+		return s.PrivateHostId, nil
+	}
+	if s.PrivateHost != nil {
+		found, err := iaas.NewPrivateHostOp(apiClient).Find(ctx, zone, s.PrivateHost.findCondition())
 		if err != nil {
 			return "", err
 		}
@@ -146,10 +170,12 @@ func (p *ServerGroupInstancePlan) String() string {
 }
 
 type ServerGroupDiskTemplate struct {
-	NamePrefix  string              `yaml:"name_prefix"` // {{.ServerName}}{{.Name}}{{.Number}}
-	Tags        []string            `yaml:"tags" validate:"unique,max=10,dive,max=32"`
-	Description string              `yaml:"description" validate:"max=512"`
-	IconID      *IdOrNameOrSelector `yaml:"icon_id"`
+	NamePrefix  string   `yaml:"name_prefix"` // {{.ServerName}}{{.Name}}{{.Number}}
+	Tags        []string `yaml:"tags" validate:"unique,max=10,dive,max=32"`
+	Description string   `yaml:"description" validate:"max=512"`
+
+	IconId string              `yaml:"icon_id"`
+	Icon   *IdOrNameOrSelector `yaml:"icon"`
 
 	// ブランクディスクの場合は以下3つをゼロ値にする
 	SourceArchiveSelector *NameOrSelector `yaml:"source_archive"`
@@ -194,6 +220,9 @@ func (t *ServerGroupDiskTemplate) Validate(ctx context.Context, apiClient iaas.A
 			errors = multierror.Append(errors, err)
 		}
 	}
+	if t.IconId != "" && t.Icon != nil {
+		errors = multierror.Append(errors, fmt.Errorf("only one of icon and icon_id can be specified"))
+	}
 
 	if _, _, err := t.FindDiskSource(ctx, apiClient, zone); err != nil {
 		errors = multierror.Append(errors, err)
@@ -205,8 +234,11 @@ func (t *ServerGroupDiskTemplate) Validate(ctx context.Context, apiClient iaas.A
 }
 
 func (t *ServerGroupDiskTemplate) FindIconID(ctx context.Context, apiClient iaas.APICaller) (string, error) {
-	if t.IconID != nil {
-		found, err := iaas.NewIconOp(apiClient).Find(ctx, t.IconID.findCondition())
+	if t.IconId != "" {
+		return t.IconId, nil
+	}
+	if t.Icon != nil {
+		found, err := iaas.NewIconOp(apiClient).Find(ctx, t.Icon.findCondition())
 		if err != nil {
 			return "", err
 		}
@@ -274,16 +306,14 @@ type ServerGroupDiskEditTemplate struct {
 	ChangePartitionUUID bool                      `yaml:"change_partition_uuid"`
 	StartupScripts      []config.StringOrFilePath `yaml:"startup_scripts"`
 
-	SSHKeys   []config.StringOrFilePath `yaml:"ssh_keys"`
-	SSHKeyIDs []string                  `yaml:"ssh_key_ids"`
+	SSHKeys []config.StringOrFilePath `yaml:"ssh_keys"`
 }
 
 func (t *ServerGroupDiskEditTemplate) Validate() []error {
 	hasValue := t.HostNamePrefix != "" ||
 		t.Password != "" ||
 		len(t.StartupScripts) > 0 ||
-		len(t.SSHKeys) > 0 ||
-		len(t.SSHKeyIDs) > 0
+		len(t.SSHKeys) > 0
 
 	if t.Disabled && hasValue {
 		return []error{fmt.Errorf("disabled=true but a value is specified")}
@@ -317,8 +347,11 @@ type ServerGroupNICTemplate struct {
 	AssignCidrBlock  string                  `yaml:"assign_cidr_block" validate:"omitempty,cidrv4"`        // 上流がスイッチの場合(ルータ含む)に割り当てるIPアドレスのCIDRブロック
 	AssignNetMaskLen int                     `yaml:"assign_netmask_len" validate:"omitempty,min=1,max=32"` // 上流がスイッチの場合(ルータ含む)に割り当てるサブネットマスク長
 	DefaultRoute     string                  `yaml:"default_route" validate:"omitempty,ipv4"`
-	PacketFilterID   *IdOrNameOrSelector     `yaml:"packet_filter_id"`
-	ExposeInfo       *ServerGroupNICMetadata `yaml:"expose"`
+
+	PacketFilterId string              `yaml:"packet_filter_id"`
+	PacketFilter   *IdOrNameOrSelector `yaml:"packet_filter"`
+
+	ExposeInfo *ServerGroupNICMetadata `yaml:"expose"`
 }
 
 func (t *ServerGroupNICTemplate) Validate(parent *ParentResourceDef, maxServerNum, nicIndex int) []error {
@@ -327,6 +360,10 @@ func (t *ServerGroupNICTemplate) Validate(parent *ParentResourceDef, maxServerNu
 	}
 
 	errors := &multierror.Error{}
+	if t.PacketFilterId != "" && t.PacketFilter != nil {
+		errors = multierror.Append(errors, fmt.Errorf("only one of packet_filter and packet_filter_id can be specified"))
+	}
+
 	hasNetworkSettings := t.AssignCidrBlock != "" || t.AssignNetMaskLen > 0 || t.DefaultRoute != ""
 	if t.Upstream.UpstreamShared() && hasNetworkSettings {
 		return []error{fmt.Errorf("upstream=shared but network settings are specified")}
@@ -365,8 +402,11 @@ func (t *ServerGroupNICTemplate) Validate(parent *ParentResourceDef, maxServerNu
 }
 
 func (t *ServerGroupNICTemplate) FindPacketFilterId(ctx context.Context, apiClient iaas.APICaller, zone string) (string, error) {
-	if t.PacketFilterID != nil {
-		found, err := iaas.NewPacketFilterOp(apiClient).Find(ctx, zone, t.PacketFilterID.findCondition())
+	if t.PacketFilterId != "" {
+		return t.PacketFilterId, nil
+	}
+	if t.PacketFilter != nil {
+		found, err := iaas.NewPacketFilterOp(apiClient).Find(ctx, zone, t.PacketFilter.findCondition())
 		if err != nil {
 			return "", err
 		}

--- a/core/server_group_instance_template.go
+++ b/core/server_group_instance_template.go
@@ -63,12 +63,33 @@ func (s *ServerGroupInstanceTemplate) Validate(ctx context.Context, apiClient ia
 	if s.IconId != "" && s.Icon != nil {
 		errors = multierror.Append(errors, fmt.Errorf("only one of icon and icon_id can be specified"))
 	}
+	if s.IconId != "" {
+		loadCtx, ok := ctx.(*config.LoadConfigContext)
+		if ok {
+			loadCtx.Logger().Warn("message", "icon_id is deprecated. use icon instead") // nolint:errcheck
+		}
+	}
+
 	if s.CDROMId != "" && s.CDROM != nil {
 		errors = multierror.Append(errors, fmt.Errorf("only one of cdrom and cdrom_id can be specified"))
 	}
+	if s.CDROMId != "" {
+		loadCtx, ok := ctx.(*config.LoadConfigContext)
+		if ok {
+			loadCtx.Logger().Warn("message", "cdrom_id is deprecated. use cdrom instead") // nolint:errcheck
+		}
+	}
+
 	if s.PrivateHostId != "" && s.PrivateHost != nil {
 		errors = multierror.Append(errors, fmt.Errorf("only one of private_host and private_host_id can be specified"))
 	}
+	if s.PrivateHostId != "" {
+		loadCtx, ok := ctx.(*config.LoadConfigContext)
+		if ok {
+			loadCtx.Logger().Warn("message", "private_host_id is deprecated. use private_host instead") // nolint:errcheck
+		}
+	}
+
 	if err := s.Plan.Validate(ctx, apiClient, def.Zone); err != nil {
 		errors = multierror.Append(errors, err)
 	}
@@ -89,7 +110,7 @@ func (s *ServerGroupInstanceTemplate) Validate(ctx context.Context, apiClient ia
 	}
 
 	for i, nic := range s.NetworkInterfaces {
-		errors = multierror.Append(errors, nic.Validate(def.ParentDef, def.MaxSize, i)...)
+		errors = multierror.Append(errors, nic.Validate(ctx, def.ParentDef, def.MaxSize, i)...)
 	}
 
 	return errors.Errors
@@ -223,6 +244,12 @@ func (t *ServerGroupDiskTemplate) Validate(ctx context.Context, apiClient iaas.A
 	if t.IconId != "" && t.Icon != nil {
 		errors = multierror.Append(errors, fmt.Errorf("only one of icon and icon_id can be specified"))
 	}
+	if t.IconId != "" {
+		loadCtx, ok := ctx.(*config.LoadConfigContext)
+		if ok {
+			loadCtx.Logger().Warn("message", "icon_id is deprecated. use icon instead") // nolint:errcheck
+		}
+	}
 
 	if _, _, err := t.FindDiskSource(ctx, apiClient, zone); err != nil {
 		errors = multierror.Append(errors, err)
@@ -354,7 +381,7 @@ type ServerGroupNICTemplate struct {
 	ExposeInfo *ServerGroupNICMetadata `yaml:"expose"`
 }
 
-func (t *ServerGroupNICTemplate) Validate(parent *ParentResourceDef, maxServerNum, nicIndex int) []error {
+func (t *ServerGroupNICTemplate) Validate(ctx context.Context, parent *ParentResourceDef, maxServerNum, nicIndex int) []error {
 	if errs := validate.StructWithMultiError(t); len(errs) > 0 {
 		return errs
 	}
@@ -362,6 +389,12 @@ func (t *ServerGroupNICTemplate) Validate(parent *ParentResourceDef, maxServerNu
 	errors := &multierror.Error{}
 	if t.PacketFilterId != "" && t.PacketFilter != nil {
 		errors = multierror.Append(errors, fmt.Errorf("only one of packet_filter and packet_filter_id can be specified"))
+	}
+	if t.PacketFilterId != "" {
+		loadCtx, ok := ctx.(*config.LoadConfigContext)
+		if ok {
+			loadCtx.Logger().Warn("message", "icon_id is deprecated. use icon instead") // nolint:errcheck
+		}
 	}
 
 	hasNetworkSettings := t.AssignCidrBlock != "" || t.AssignNetMaskLen > 0 || t.DefaultRoute != ""

--- a/core/server_group_instance_template_test.go
+++ b/core/server_group_instance_template_test.go
@@ -311,6 +311,48 @@ func TestServerGroupInstanceTemplate_Validate(t *testing.T) {
 			},
 		},
 		{
+			name: "icon",
+			template: &ServerGroupInstanceTemplate{
+				Plan: &ServerGroupInstancePlan{
+					Core:   1,
+					Memory: 1,
+				},
+				Icon:   &IdOrNameOrSelector{ResourceSelector{Names: []string{"test"}}},
+				IconId: "123456789012",
+			},
+			want: []error{
+				fmt.Errorf("only one of icon and icon_id can be specified"),
+			},
+		},
+		{
+			name: "cdrom",
+			template: &ServerGroupInstanceTemplate{
+				Plan: &ServerGroupInstancePlan{
+					Core:   1,
+					Memory: 1,
+				},
+				CDROM:   &IdOrNameOrSelector{ResourceSelector{Names: []string{"test"}}},
+				CDROMId: "123456789012",
+			},
+			want: []error{
+				fmt.Errorf("only one of cdrom and cdrom_id can be specified"),
+			},
+		},
+		{
+			name: "private_host",
+			template: &ServerGroupInstanceTemplate{
+				Plan: &ServerGroupInstancePlan{
+					Core:   1,
+					Memory: 1,
+				},
+				PrivateHost:   &IdOrNameOrSelector{ResourceSelector{Names: []string{"test"}}},
+				PrivateHostId: "123456789012",
+			},
+			want: []error{
+				fmt.Errorf("only one of private_host and private_host_id can be specified"),
+			},
+		},
+		{
 			name: "cloud-config",
 			template: &ServerGroupInstanceTemplate{
 				Plan: &ServerGroupInstancePlan{
@@ -360,6 +402,17 @@ func TestServerGroupNICTemplate_Validate(t *testing.T) {
 			template: &ServerGroupNICTemplate{Upstream: &ServerGroupNICUpstream{shared: true}},
 			args:     args{maxServerNum: 1},
 			want:     nil,
+		},
+		{
+			name: "packet_filter",
+			template: &ServerGroupNICTemplate{
+				Upstream:       &ServerGroupNICUpstream{shared: true},
+				PacketFilter:   &IdOrNameOrSelector{ResourceSelector{Names: []string{"test"}}},
+				PacketFilterId: "123456789012",
+			},
+			want: []error{
+				fmt.Errorf("only one of packet_filter and packet_filter_id can be specified"),
+			},
 		},
 		{
 			name: "shared with network settings",

--- a/core/server_group_instance_template_test.go
+++ b/core/server_group_instance_template_test.go
@@ -15,6 +15,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -491,7 +492,7 @@ func TestServerGroupNICTemplate_Validate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t1 *testing.T) {
-			got := tt.template.Validate(nil, tt.args.maxServerNum, 0)
+			got := tt.template.Validate(context.Background(), nil, tt.args.maxServerNum, 0)
 			require.EqualValues(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
closes #401 

サーバグループの項目のうちIDを指定する項目に対しセレクタを指定可能にする。

- `*_id`フィールドも残しておく
- バリデーションで新旧両方のフィールドが指定されたらエラーとする
- バリデーションで旧フィールドが使用されていたら警告(`level=warn`のログ)を出力する