### PR TITLE
水平スケールで複数ゾーンを利用可能に

### DIFF
--- a/commands/core/example/example.yaml
+++ b/commands/core/example/example.yaml
@@ -27,7 +27,7 @@ resources:
 
     # グループ内の各サーバの名前のプレフィックス
     server_name_prefix: "server-group"
-    zone: "is1a"
+    zones: ["is1a", "is1b"]
 
     min_size: 5   # 最小インスタンス数
     max_size: 20  # 最大インスタンス数

--- a/core/server_group_instance_template.go
+++ b/core/server_group_instance_template.go
@@ -90,11 +90,13 @@ func (s *ServerGroupInstanceTemplate) Validate(ctx context.Context, apiClient ia
 		}
 	}
 
-	if err := s.Plan.Validate(ctx, apiClient, def.Zone); err != nil {
-		errors = multierror.Append(errors, err)
-	}
-	for _, disk := range s.Disks {
-		errors = multierror.Append(errors, disk.Validate(ctx, apiClient, def.Zone)...)
+	for _, zone := range def.Zones {
+		if err := s.Plan.Validate(ctx, apiClient, zone); err != nil {
+			errors = multierror.Append(errors, err)
+		}
+		for _, disk := range s.Disks {
+			errors = multierror.Append(errors, disk.Validate(ctx, apiClient, zone)...)
+		}
 	}
 
 	// TODO EditParameter/CloudConfigそれぞれにおいて、Disks[0]が存在&対応していることを検証

--- a/e2e/horizontal_scaling/autoscaler.yaml
+++ b/e2e/horizontal_scaling/autoscaler.yaml
@@ -1,7 +1,7 @@
 resources:
   - type: ServerGroup
     name: "autoscaler-e2e-horizontal-scaling"
-    zone: "is1a"
+    zones: ["is1a", "is1b"]
     min_size: 0
     max_size: 5
 

--- a/handlers/elb/servers_handler.go
+++ b/handlers/elb/servers_handler.go
@@ -279,8 +279,8 @@ func (h *ServersHandler) deleteServer(ctx *handlers.HandlerContext, instance *ha
 	}
 
 	shouldUpdate := false
-	var servers []*iaas.ProxyLBServer
 	fn := func(ip string, port int) error {
+		var servers []*iaas.ProxyLBServer
 		for _, s := range current.Servers {
 			if s.IPAddress == ip && s.Port == port {
 				shouldUpdate = true
@@ -292,6 +292,7 @@ func (h *ServersHandler) deleteServer(ctx *handlers.HandlerContext, instance *ha
 			}
 			servers = append(servers, s)
 		}
+		current.Servers = servers
 		return nil
 	}
 	if err := nic.EachIPAndExposedPort(fn); err != nil {
@@ -306,7 +307,7 @@ func (h *ServersHandler) deleteServer(ctx *handlers.HandlerContext, instance *ha
 			HealthCheck:   current.HealthCheck,
 			SorryServer:   current.SorryServer,
 			BindPorts:     current.BindPorts,
-			Servers:       servers,
+			Servers:       current.Servers,
 			Rules:         current.Rules,
 			LetsEncrypt:   current.LetsEncrypt,
 			StickySession: current.StickySession,

--- a/handlers/server/horizontal_scale_handler.go
+++ b/handlers/server/horizontal_scale_handler.go
@@ -114,7 +114,7 @@ func (h *HorizontalScaleHandler) createServer(ctx *handlers.HandlerContext, req 
 	}
 
 	if err := ctx.Report(handler.HandleResponse_RUNNING,
-		"created: {ID:%s, Name:%s}", createdServer.ID, createdServer.Name); err != nil {
+		"created: {Zone:%s, ID:%s, Name:%s}", createdServer.Zone.Name, createdServer.ID, createdServer.Name); err != nil {
 		return err
 	}
 
@@ -154,8 +154,8 @@ func (h *HorizontalScaleHandler) createServer(ctx *handlers.HandlerContext, req 
 		}
 
 		if err := ctx.Report(handler.HandleResponse_RUNNING,
-			"created disk[%d]: {ID:%s, Name:%s, ServerID:%s}",
-			i, disk.ID, disk.Name, createdServer.ID); err != nil {
+			"created disk[%d]: {Zone:%s, ID:%s, Name:%s, ServerID:%s}",
+			i, server.Zone, disk.ID, disk.Name, createdServer.ID); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
水平スケールで対象ゾーンを複数指定することで指定した各ゾーンにサーバを分散配置出来るようにする。

利用例:
```yaml
resources:
  - type: ServerGroup
    name: "autoscaler-selector-test"
    server_name_prefix: "autoscaler-selector-test"
    zones: ["is1a", "is1b", "tk1a", "tk1b"] # 4つのゾーンに分散配置する
    
    # ...(以下略)
```

## 変更点

- `type: ServerGroup`なリソースで`zones`を指定可能に
  - 従来の`zone`も引き続き利用可能
  - `zone`と`zones`の同時利用はできない(起動時などに行われるバリデーションでエラーにする)
  - `zones`に複数の要素を指定した場合、`parent`に指定可能な要素を制限する
    - `parent`が`LoadBalancer`の場合はエラーとする(ロードバランサーのみ非グローバルリソースなため)

## ゾーン分散の挙動

- サーバ作成時にサーバグループ内でのインデックス(順序)を算出(既存の処理)
- コンフィギュレーションで指定されたゾーン一覧とインデックスからどのゾーンに配置するかを決定
  - `利用ゾーン = ゾーン一覧[インデックス % ゾーン一覧の要素数]`

Note: ゾーン決定の際は既存のサーバの配置状況は考慮されません。
このため、ゾーンごとのサーバ配置状況に偏りがあっても考慮されない点に注意が必要です。
(単一ゾーンで運用していたものを後から複数ゾーンに拡張する場合などが該当します) 

例: `is1a`ゾーンのみで5〜10台で運用していたものを`is1a`+`tk1b`に分散させるように変更した場合
この場合is1aの5台については再配置されないため手動での再配置(一度削除してからスケールアップさせるなど)が必要です。