### PR TITLE
HostNameFormatが空の場合のデフォルト値を文字列+数値を受け入れ可能なフォーマットにする

### DIFF
--- a/core/server_group_instance_template.go
+++ b/core/server_group_instance_template.go
@@ -248,9 +248,13 @@ func (t *ServerGroupDiskTemplate) DiskName(serverName string, index int) string 
 //
 // HostNamePrefixが空の場合はserverNameをそのまま返す
 func (t *ServerGroupDiskEditTemplate) HostName(serverName string, index int) string {
+	if t.HostNameFormat == "" && t.HostNamePrefix == "" {
+		return serverName
+	}
+
 	nameFormat := t.HostNameFormat
 	if nameFormat == "" {
-		nameFormat = "%s"
+		nameFormat = "%s-%03d"
 	}
 	if t.HostNamePrefix != "" {
 		nameFormat = "%s-%03d"


### PR DESCRIPTION
#407 の補完

ホスト名を決定する際HostNameFormatが空の場合はフォーマットとして`%s`を用いていたことが原因でホスト名として不正な文字を設定してしまう問題を修正する