### PR TITLE
infoログ追加: resource-name,desired-state-name

### DIFF
--- a/core/service.go
+++ b/core/service.go
@@ -36,7 +36,15 @@ func NewScalingService(instance *Core) *ScalingService {
 }
 
 func (s *ScalingService) Up(ctx context.Context, req *request.ScalingRequest) (*request.ScalingResponse, error) {
-	if err := s.instance.logger.Info("request", requestTypeUp, "message", "request received"); err != nil {
+	keyvals := []interface{}{
+		"request", requestTypeUp,
+		"message", "request received",
+		"resource", req.ResourceName,
+	}
+	if req.DesiredStateName != "" {
+		keyvals = append(keyvals, "desired", req.DesiredStateName)
+	}
+	if err := s.instance.logger.Info(keyvals...); err != nil {
 		return nil, err
 	}
 	if err := s.instance.logger.Debug("request", req); err != nil {
@@ -67,7 +75,16 @@ func (s *ScalingService) Up(ctx context.Context, req *request.ScalingRequest) (*
 }
 
 func (s *ScalingService) Down(ctx context.Context, req *request.ScalingRequest) (*request.ScalingResponse, error) {
-	if err := s.instance.logger.Info("request", requestTypeDown, "message", "request received"); err != nil {
+	keyvals := []interface{}{
+		"request", requestTypeDown,
+		"message", "request received",
+		"resource", req.ResourceName,
+	}
+	if req.DesiredStateName != "" {
+		keyvals = append(keyvals, "desired", req.DesiredStateName)
+	}
+
+	if err := s.instance.logger.Info(keyvals...); err != nil {
 		return nil, err
 	}
 	if err := s.instance.logger.Debug("request", req); err != nil {


### PR DESCRIPTION
closes #405 

CoreがUp/Downリクエストを受けた時のinfoログに項目を追加する

```
timestamp=2022-09-28T13:46:23+09:00 level=info request=Up message="request received" resource=default desired=foobar
```