### PR TITLE
cooldownパラメータをup/downで分離

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,7 +47,8 @@ jobs:
       - name: make lint-go
         run:  |
           # Explicitly set GOROOT to avoid golangci-lint/issues/3107
-          export GOROOT=$(go env GOROOT)
+          GOROOT=$(go env GOROOT)
+          export GOROOT
           make lint-go
 
   licenses-check:

--- a/commands/core/example/example.yaml
+++ b/commands/core/example/example.yaml
@@ -190,6 +190,11 @@ resources:
 ## オートスケーラーの動作設定
 autoscaler:
   cooldown: 600 # ジョブの連続実行を抑止するためのクールダウン期間を秒数で指定。デフォルト: 600(10分)
+# 以下のようにup/downごとに指定することも可能(cooldownに直接数値を指定した場合、up/downともに同じ値が設定される)
+#  cooldown:
+#    up: 600
+#    down: 600
+
   shutdown_grace_period: 600 # SIGINTまたはSIGTERMをを受け取った際の処理完了待ち猶予時間を秒で指定。デフォルト: 600(10分)
 
 #  # Exporterの設定

--- a/core/config.go
+++ b/core/config.go
@@ -224,7 +224,7 @@ func (c *Config) ValidateCustomHandler(ctx context.Context, handler *Handler) er
 
 // AutoScalerConfig オートスケーラー自体の動作設定
 type AutoScalerConfig struct {
-	CoolDownSec            int                    `yaml:"cooldown"`              // 同一ジョブの連続実行を防ぐための冷却期間(単位:秒)
+	CoolDown               *CoolDown              `yaml:"cooldown"`              // 同一ジョブの連続実行を防ぐための冷却期間(単位:秒)
 	ShutdownGracePeriodSec int                    `yaml:"shutdown_grace_period"` // SIGINTまたはSIGTERMをを受け取った際の処理完了待ち猶予時間(単位:秒)
 	ExporterConfig         *config.ExporterConfig `yaml:"exporter_config"`       // Exporter設定
 	HandlersConfig         *HandlersConfig        `yaml:"handlers_config"`       // ビルトインハンドラーの設定
@@ -232,14 +232,6 @@ type AutoScalerConfig struct {
 
 func (c *AutoScalerConfig) Validate(ctx context.Context) []error {
 	return c.HandlersConfig.Validate(ctx)
-}
-
-func (c *AutoScalerConfig) JobCoolDownTime() time.Duration {
-	sec := c.CoolDownSec
-	if sec <= 0 {
-		return defaults.CoolDownTime
-	}
-	return time.Duration(sec) * time.Second
 }
 
 func (c *AutoScalerConfig) ShutdownGracePeriod() time.Duration {

--- a/core/cooldown.go
+++ b/core/cooldown.go
@@ -1,0 +1,48 @@
+// Copyright 2021-2023 The sacloud/autoscaler Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+
+	"github.com/goccy/go-yaml"
+)
+
+// CoolDown スケール動作を繰り返し実行する際の冷却期間
+type CoolDown struct {
+	Up   int `yaml:"up"`
+	Down int `yaml:"down"`
+}
+
+func (c *CoolDown) UnmarshalYAML(ctx context.Context, data []byte) error {
+	// まずintで指定されているか確認
+	var cd int
+	if err := yaml.UnmarshalContext(ctx, data, &cd); err == nil { // エラーなくUnmarshalできたら
+		*c = CoolDown{
+			Up:   cd,
+			Down: cd,
+		}
+		return nil
+	}
+
+	// int以外の場合はstructとしてUnmarshal
+	type alias CoolDown
+	var v alias
+	if err := yaml.UnmarshalContext(ctx, data, &v); err != nil {
+		return err
+	}
+	*c = CoolDown(v)
+	return nil
+}

--- a/core/cooldown.go
+++ b/core/cooldown.go
@@ -16,8 +16,10 @@ package core
 
 import (
 	"context"
+	"time"
 
 	"github.com/goccy/go-yaml"
+	"github.com/sacloud/autoscaler/defaults"
 )
 
 // CoolDown スケール動作を繰り返し実行する際の冷却期間
@@ -45,4 +47,21 @@ func (c *CoolDown) UnmarshalYAML(ctx context.Context, data []byte) error {
 	}
 	*c = CoolDown(v)
 	return nil
+}
+
+func (c *CoolDown) Duration(requestType RequestTypes) time.Duration {
+	switch requestType {
+	case requestTypeUp:
+		return c.duration(c.Up)
+	case requestTypeDown:
+		return c.duration(c.Down)
+	}
+	return defaults.CoolDownTime
+}
+
+func (c *CoolDown) duration(sec int) time.Duration {
+	if sec <= 0 {
+		return defaults.CoolDownTime
+	}
+	return time.Duration(sec) * time.Second
 }

--- a/core/cooldown_test.go
+++ b/core/cooldown_test.go
@@ -1,0 +1,76 @@
+// Copyright 2021-2023 The sacloud/autoscaler Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoolDown_UnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		want    *CoolDown
+		wantErr bool
+	}{
+		{
+			name: "struct",
+			data: []byte(`
+up: 1
+down: 2
+`),
+			want: &CoolDown{
+				Up:   1,
+				Down: 2,
+			},
+			wantErr: false,
+		},
+		{
+			name: "int",
+			data: []byte(`1`),
+			want: &CoolDown{
+				Up:   1,
+				Down: 1,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "invalid char",
+			data:    []byte(`a`),
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			data:    []byte(``),
+			want:    &CoolDown{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &CoolDown{}
+			if err := c.UnmarshalYAML(context.Background(), tt.data); (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				require.EqualValues(t, tt.want, c)
+			}
+		})
+	}
+}

--- a/core/core.go
+++ b/core/core.go
@@ -185,7 +185,7 @@ func (c *Core) Down(ctx *RequestContext) (*JobStatus, string, error) {
 func (c *Core) currentJob(ctx *RequestContext) *JobStatus {
 	job, ok := c.jobs[ctx.JobID()]
 	if !ok {
-		job = NewJobStatus(ctx.Request(), c.config.AutoScaler.JobCoolDownTime())
+		job = NewJobStatus(ctx.Request(), c.config.AutoScaler.CoolDown)
 		c.jobs[ctx.JobID()] = job
 	}
 	return job
@@ -193,7 +193,7 @@ func (c *Core) currentJob(ctx *RequestContext) *JobStatus {
 
 func (c *Core) handle(ctx *RequestContext) (*JobStatus, string, error) {
 	job := c.currentJob(ctx)
-	if !job.Acceptable() {
+	if !job.Acceptable(ctx.request.requestType) {
 		ctx.Logger().Info("status", request.ScalingJobStatus_JOB_IGNORED, "message", "job is in an unacceptable state") //nolint
 		return job, "job is in an unacceptable state", nil
 	}

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -174,7 +174,10 @@ func TestLoadAndValidate(t *testing.T) {
 					},
 				},
 				AutoScaler: AutoScalerConfig{
-					CoolDownSec: 5,
+					CoolDown: &CoolDown{
+						Up:   5,
+						Down: 5,
+					},
 				},
 				strictMode: false,
 			},
@@ -200,7 +203,10 @@ func TestLoadAndValidate(t *testing.T) {
 					},
 				},
 				AutoScaler: AutoScalerConfig{
-					CoolDownSec: 5,
+					CoolDown: &CoolDown{
+						Up:   5,
+						Down: 5,
+					},
 				},
 				strictMode: true, // 引数での指定がConfigに引き継がれているはず
 			},

--- a/core/job_test.go
+++ b/core/job_test.go
@@ -25,84 +25,143 @@ func TestJobStatus_Acceptable(t *testing.T) {
 	type fields struct {
 		status        request.ScalingJobStatus
 		statusChanged time.Time
-		coolDownTime  time.Duration
+		coolDown      *CoolDown
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		want   bool
+		name        string
+		fields      fields
+		requestType RequestTypes
+		want        bool
 	}{
 		{
-			name: "returns true if status is DONE and is not in cooling down time",
+			name: "returns true if status is DONE and is not in cooling down time: up",
 			fields: fields{
 				status:        request.ScalingJobStatus_JOB_DONE,
 				statusChanged: time.Now().Add(-2 * time.Second),
-				coolDownTime:  time.Second,
+				coolDown: &CoolDown{
+					Up:   1,
+					Down: 1000,
+				},
 			},
-			want: true,
+			requestType: requestTypeUp,
+			want:        true,
 		},
 		{
-			name: "returns false if is in cooling down time",
+			name: "returns false if is in cooling down time: up",
 			fields: fields{
 				status:        request.ScalingJobStatus_JOB_DONE,
 				statusChanged: time.Now(),
-				coolDownTime:  10 * time.Second,
+				coolDown: &CoolDown{
+					Up:   1000,
+					Down: 1,
+				},
 			},
-			want: false,
+			requestType: requestTypeUp,
+			want:        false,
+		},
+		{
+			name: "returns true if status is DONE and is not in cooling down time: down",
+			fields: fields{
+				status:        request.ScalingJobStatus_JOB_DONE,
+				statusChanged: time.Now().Add(-2 * time.Second),
+				coolDown: &CoolDown{
+					Up:   1000,
+					Down: 1,
+				},
+			},
+			requestType: requestTypeDown,
+			want:        true,
+		},
+		{
+			name: "returns false if is in cooling down time: down",
+			fields: fields{
+				status:        request.ScalingJobStatus_JOB_DONE,
+				statusChanged: time.Now(),
+				coolDown: &CoolDown{
+					Up:   1,
+					Down: 1000,
+				},
+			},
+			requestType: requestTypeDown,
+			want:        false,
 		},
 		{
 			name: "returns false if status is RUNNING",
 			fields: fields{
 				status:        request.ScalingJobStatus_JOB_RUNNING,
 				statusChanged: time.Now().Add(-2 * time.Second),
-				coolDownTime:  time.Second,
+				coolDown: &CoolDown{
+					Up:   1,
+					Down: 1,
+				},
 			},
-			want: false,
+			requestType: requestTypeUp,
+			want:        false,
 		},
 		{
 			name: "returns true if status is UNKNOWN",
 			fields: fields{
 				status:        request.ScalingJobStatus_JOB_UNKNOWN,
 				statusChanged: time.Now().Add(-2 * time.Second),
-				coolDownTime:  time.Second,
+				coolDown: &CoolDown{
+					Up:   1,
+					Down: 1,
+				},
 			},
-			want: true,
+			requestType: requestTypeUp,
+			want:        true,
 		},
 		{
 			name: "returns true if status is CANCELED",
 			fields: fields{
 				status:        request.ScalingJobStatus_JOB_CANCELED,
 				statusChanged: time.Now().Add(-2 * time.Second),
-				coolDownTime:  time.Second,
+				coolDown: &CoolDown{
+					Up:   1,
+					Down: 1,
+				},
 			},
-			want: true,
+			requestType: requestTypeUp,
+			want:        true,
 		},
 		{
 			name: "returns true if status is DONE_NOOP",
 			fields: fields{
 				status:        request.ScalingJobStatus_JOB_DONE_NOOP,
 				statusChanged: time.Now().Add(-2 * time.Second),
-				coolDownTime:  time.Second,
+				coolDown: &CoolDown{
+					Up:   1,
+					Down: 1,
+				},
 			},
-			want: true,
+			requestType: requestTypeUp,
+			want:        true,
 		},
 		{
 			name: "returns false if status is ACCEPTED",
 			fields: fields{
 				status:        request.ScalingJobStatus_JOB_ACCEPTED,
 				statusChanged: time.Now().Add(-2 * time.Second),
-				coolDownTime:  time.Second,
+				coolDown: &CoolDown{
+					Up:   1,
+					Down: 1,
+				},
 			},
-			want: false,
+			requestType: requestTypeUp,
+			want:        false,
 		},
 		{
 			name: "returns true if status is FAILED",
 			fields: fields{
 				status:        request.ScalingJobStatus_JOB_FAILED,
 				statusChanged: time.Now().Add(-2 * time.Second),
-				coolDownTime:  time.Second,
+				coolDown: &CoolDown{
+					Up:   1,
+					Down: 1,
+				},
 			},
-			want: true,
+			requestType: requestTypeUp,
+			want:        true,
 		},
 	}
 	for _, tt := range tests {
@@ -110,9 +169,9 @@ func TestJobStatus_Acceptable(t *testing.T) {
 			j := &JobStatus{
 				status:        tt.fields.status,
 				statusChanged: tt.fields.statusChanged,
-				coolDownTime:  tt.fields.coolDownTime,
+				coolDown:      tt.fields.coolDown,
 			}
-			if got := j.Acceptable(); got != tt.want {
+			if got := j.Acceptable(tt.requestType); got != tt.want {
 				t.Errorf("Acceptable() = %v, want %v", got, tt.want)
 			}
 		})

--- a/core/resource_def_server_group_test.go
+++ b/core/resource_def_server_group_test.go
@@ -591,7 +591,7 @@ func TestResourceDefServerGroup_Validate(t *testing.T) {
 					TypeName: "ServerGroup",
 					DefName:  "test",
 				},
-				Zone:   "is1a",
+				Zone:    "is1a",
 				MinSize: 1,
 				MaxSize: 1,
 				Template: &ServerGroupInstanceTemplate{


### PR DESCRIPTION
cooldownは従来以下のように指定していた。

```
autoscaler:
  cooldown: 600 # ジョブの連続実行を抑止するためのクールダウン期間を秒数で指定。デフォルト: 600(10分)
```

これをup/downそれぞれで指定可能にする。
```
autoscaler:
# 以下のようにup/downごとに指定することも可能(cooldownに直接数値を指定した場合、up/downともに同じ値が設定される)
  cooldown:
    up: 600
    down: 600
```

互換性維持のために従来の指定方法も継続してサポートする。
従来の指定がされた場合、up/down両方に指定された値が設定される。