### PR TITLE
cooldownの基準として各リソースのModifiedAtを用いる

### DIFF
--- a/core/job_test.go
+++ b/core/job_test.go
@@ -23,155 +23,154 @@ import (
 
 func TestJobStatus_Acceptable(t *testing.T) {
 	type fields struct {
-		status        request.ScalingJobStatus
-		statusChanged time.Time
-		coolDown      *CoolDown
+		status   request.ScalingJobStatus
+		coolDown *CoolDown
 	}
 	tests := []struct {
-		name        string
-		fields      fields
-		requestType RequestTypes
-		want        bool
+		name           string
+		fields         fields
+		requestType    RequestTypes
+		lastModifiedAt time.Time
+		want           bool
 	}{
 		{
 			name: "returns true if status is DONE and is not in cooling down time: up",
 			fields: fields{
-				status:        request.ScalingJobStatus_JOB_DONE,
-				statusChanged: time.Now().Add(-2 * time.Second),
+				status: request.ScalingJobStatus_JOB_DONE,
 				coolDown: &CoolDown{
 					Up:   1,
 					Down: 1000,
 				},
 			},
-			requestType: requestTypeUp,
-			want:        true,
+			lastModifiedAt: time.Now().Add(-2 * time.Second),
+			requestType:    requestTypeUp,
+			want:           true,
 		},
 		{
 			name: "returns false if is in cooling down time: up",
 			fields: fields{
-				status:        request.ScalingJobStatus_JOB_DONE,
-				statusChanged: time.Now(),
+				status: request.ScalingJobStatus_JOB_DONE,
 				coolDown: &CoolDown{
 					Up:   1000,
 					Down: 1,
 				},
 			},
-			requestType: requestTypeUp,
-			want:        false,
+			lastModifiedAt: time.Now(),
+			requestType:    requestTypeUp,
+			want:           false,
 		},
 		{
 			name: "returns true if status is DONE and is not in cooling down time: down",
 			fields: fields{
-				status:        request.ScalingJobStatus_JOB_DONE,
-				statusChanged: time.Now().Add(-2 * time.Second),
+				status: request.ScalingJobStatus_JOB_DONE,
 				coolDown: &CoolDown{
 					Up:   1000,
 					Down: 1,
 				},
 			},
-			requestType: requestTypeDown,
-			want:        true,
+			lastModifiedAt: time.Now().Add(-2 * time.Second),
+			requestType:    requestTypeDown,
+			want:           true,
 		},
 		{
 			name: "returns false if is in cooling down time: down",
 			fields: fields{
-				status:        request.ScalingJobStatus_JOB_DONE,
-				statusChanged: time.Now(),
+				status: request.ScalingJobStatus_JOB_DONE,
 				coolDown: &CoolDown{
 					Up:   1,
 					Down: 1000,
 				},
 			},
-			requestType: requestTypeDown,
-			want:        false,
+			lastModifiedAt: time.Now(),
+			requestType:    requestTypeDown,
+			want:           false,
 		},
 		{
 			name: "returns false if status is RUNNING",
 			fields: fields{
-				status:        request.ScalingJobStatus_JOB_RUNNING,
-				statusChanged: time.Now().Add(-2 * time.Second),
+				status: request.ScalingJobStatus_JOB_RUNNING,
 				coolDown: &CoolDown{
 					Up:   1,
 					Down: 1,
 				},
 			},
-			requestType: requestTypeUp,
-			want:        false,
+			lastModifiedAt: time.Now().Add(-2 * time.Second),
+			requestType:    requestTypeUp,
+			want:           false,
 		},
 		{
 			name: "returns true if status is UNKNOWN",
 			fields: fields{
-				status:        request.ScalingJobStatus_JOB_UNKNOWN,
-				statusChanged: time.Now().Add(-2 * time.Second),
+				status: request.ScalingJobStatus_JOB_UNKNOWN,
 				coolDown: &CoolDown{
 					Up:   1,
 					Down: 1,
 				},
 			},
-			requestType: requestTypeUp,
-			want:        true,
+			lastModifiedAt: time.Now().Add(-2 * time.Second),
+			requestType:    requestTypeUp,
+			want:           true,
 		},
 		{
 			name: "returns true if status is CANCELED",
 			fields: fields{
-				status:        request.ScalingJobStatus_JOB_CANCELED,
-				statusChanged: time.Now().Add(-2 * time.Second),
+				status: request.ScalingJobStatus_JOB_CANCELED,
 				coolDown: &CoolDown{
 					Up:   1,
 					Down: 1,
 				},
 			},
-			requestType: requestTypeUp,
-			want:        true,
+			lastModifiedAt: time.Now().Add(-2 * time.Second),
+			requestType:    requestTypeUp,
+			want:           true,
 		},
 		{
 			name: "returns true if status is DONE_NOOP",
 			fields: fields{
-				status:        request.ScalingJobStatus_JOB_DONE_NOOP,
-				statusChanged: time.Now().Add(-2 * time.Second),
+				status: request.ScalingJobStatus_JOB_DONE_NOOP,
 				coolDown: &CoolDown{
 					Up:   1,
 					Down: 1,
 				},
 			},
-			requestType: requestTypeUp,
-			want:        true,
+			lastModifiedAt: time.Now().Add(-2 * time.Second),
+			requestType:    requestTypeUp,
+			want:           true,
 		},
 		{
 			name: "returns false if status is ACCEPTED",
 			fields: fields{
-				status:        request.ScalingJobStatus_JOB_ACCEPTED,
-				statusChanged: time.Now().Add(-2 * time.Second),
+				status: request.ScalingJobStatus_JOB_ACCEPTED,
 				coolDown: &CoolDown{
 					Up:   1,
 					Down: 1,
 				},
 			},
-			requestType: requestTypeUp,
-			want:        false,
+			lastModifiedAt: time.Now().Add(-2 * time.Second),
+			requestType:    requestTypeUp,
+			want:           false,
 		},
 		{
 			name: "returns true if status is FAILED",
 			fields: fields{
-				status:        request.ScalingJobStatus_JOB_FAILED,
-				statusChanged: time.Now().Add(-2 * time.Second),
+				status: request.ScalingJobStatus_JOB_FAILED,
 				coolDown: &CoolDown{
 					Up:   1,
 					Down: 1,
 				},
 			},
-			requestType: requestTypeUp,
-			want:        true,
+			lastModifiedAt: time.Now().Add(-2 * time.Second),
+			requestType:    requestTypeUp,
+			want:           true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			j := &JobStatus{
-				status:        tt.fields.status,
-				statusChanged: tt.fields.statusChanged,
-				coolDown:      tt.fields.coolDown,
+				status:   tt.fields.status,
+				coolDown: tt.fields.coolDown,
 			}
-			if got := j.Acceptable(tt.requestType); got != tt.want {
+			if got := j.Acceptable(tt.requestType, tt.lastModifiedAt); got != tt.want {
 				t.Errorf("Acceptable() = %v, want %v", got, tt.want)
 			}
 		})

--- a/core/resource_def_elb.go
+++ b/core/resource_def_elb.go
@@ -17,6 +17,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/sacloud/autoscaler/validate"
@@ -133,4 +134,19 @@ func (d *ResourceDefELB) findCloudResources(ctx context.Context, apiClient iaas.
 		return nil, validate.Errorf("resource not found with selector: %s", selector.String())
 	}
 	return found.ProxyLBs, nil
+}
+
+// LastModifiedAt この定義が対象とするリソース(群)の最終更新日時を返す
+func (d *ResourceDefELB) LastModifiedAt(ctx *RequestContext, apiClient iaas.APICaller) (time.Time, error) {
+	cloudResources, err := d.findCloudResources(ctx, apiClient)
+	if err != nil {
+		return time.Time{}, err
+	}
+	last := time.Time{}
+	for _, r := range cloudResources {
+		if r.GetModifiedAt().After(last) {
+			last = r.GetModifiedAt()
+		}
+	}
+	return last, nil
 }

--- a/core/resource_def_server.go
+++ b/core/resource_def_server.go
@@ -17,6 +17,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/sacloud/autoscaler/validate"
@@ -167,6 +168,21 @@ func (d *ResourceDefServer) findCloudResources(ctx context.Context, apiClient ia
 	}
 
 	return results, nil
+}
+
+// LastModifiedAt この定義が対象とするリソース(群)の最終更新日時を返す
+func (d *ResourceDefServer) LastModifiedAt(ctx *RequestContext, apiClient iaas.APICaller) (time.Time, error) {
+	cloudResources, err := d.findCloudResources(ctx, apiClient)
+	if err != nil {
+		return time.Time{}, err
+	}
+	last := time.Time{}
+	for _, r := range cloudResources {
+		if r.GetModifiedAt().After(last) {
+			last = r.GetModifiedAt()
+		}
+	}
+	return last, nil
 }
 
 type sakuraCloudServer struct {

--- a/core/resource_def_server_group.go
+++ b/core/resource_def_server_group.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/sacloud/autoscaler/config"
@@ -328,4 +329,23 @@ func (d *ResourceDefServerGroup) filterCloudServers(servers []*iaas.Server) []*i
 		}
 	}
 	return filtered
+}
+
+// LastModifiedAt この定義が対象とするリソース(群)の最終更新日時を返す
+func (d *ResourceDefServerGroup) LastModifiedAt(ctx *RequestContext, apiClient iaas.APICaller) (time.Time, error) {
+	cloudResources, err := d.findCloudResources(ctx, apiClient)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return d.lastModifiedAt(cloudResources), nil
+}
+
+func (d *ResourceDefServerGroup) lastModifiedAt(cloudResources []*iaas.Server) time.Time {
+	last := time.Time{}
+	for _, r := range cloudResources {
+		if r.GetModifiedAt().After(last) {
+			last = r.GetModifiedAt()
+		}
+	}
+	return last
 }

--- a/core/resource_definition.go
+++ b/core/resource_definition.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"context"
+	"time"
 
 	"github.com/sacloud/autoscaler/defaults"
 	"github.com/sacloud/iaas-api-go"
@@ -34,6 +35,9 @@ type ResourceDefinition interface {
 	//
 	// TypeとSelectorを元にさくらのクラウドAPIを用いて実リソースを検索、Resourceを作成して返す
 	Compute(ctx *RequestContext, apiClient iaas.APICaller) (Resources, error)
+
+	// LastModifiedAt この定義が対象とするリソース(群)の最終更新を返す
+	LastModifiedAt(ctx *RequestContext, apiClient iaas.APICaller) (time.Time, error)
 }
 
 // ResourceDefBase 全てのリソース定義が実装すべき基本プロパティ

--- a/core/resource_definitions.go
+++ b/core/resource_definitions.go
@@ -237,3 +237,22 @@ func (rds *ResourceDefinitions) handleAllByFunc(computed Computed, handlers Hand
 	}
 	return nil
 }
+
+// LastModifiedAt 内包する定義群が対象とするリソース(群)の更新日時のうち、最も新しい(時間が遅い)値を返す
+func (rds *ResourceDefinitions) LastModifiedAt(ctx *RequestContext, apiClient iaas.APICaller) (time.Time, error) {
+	lastModifiedAt := time.Time{}
+	err := rds.walk(*rds, func(r ResourceDefinition) error {
+		t, err := r.LastModifiedAt(ctx, apiClient)
+		if err != nil {
+			return err
+		}
+		if t.After(lastModifiedAt) {
+			lastModifiedAt = t
+		}
+		return nil
+	})
+	if err != nil {
+		return time.Time{}, err
+	}
+	return lastModifiedAt, nil
+}

--- a/core/resource_parent.go
+++ b/core/resource_parent.go
@@ -136,10 +136,11 @@ func (r *ParentResource) refresh(ctx *RequestContext) error {
 		}
 	case ResourceTypeRouter:
 		op := iaas.NewInternetOp(r.apiClient)
-		found, err = op.Read(ctx, r.zone, r.resource.GetID())
+		read, err := op.Read(ctx, r.zone, r.resource.GetID())
 		if err != nil {
 			return fmt.Errorf("computing status failed: %s", err)
 		}
+		found = &sakuraCloudRouter{Internet: read, zone: r.zone}
 	case ResourceTypeLoadBalancer:
 		op := iaas.NewLoadBalancerOp(r.apiClient)
 		found, err = op.Read(ctx, r.zone, r.resource.GetID())

--- a/core/resource_stub_test.go
+++ b/core/resource_stub_test.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"context"
+	"time"
 
 	"github.com/sacloud/iaas-api-go"
 )
@@ -26,6 +27,9 @@ type stubResourceDef struct {
 
 	Dummy        string `validate:"omitempty,oneof=value1 value2"`
 	validateFunc func(ctx context.Context, apiClient iaas.APICaller) []error
+
+	lastModifiedAt    time.Time
+	lastmodifiedAtErr error
 }
 
 func (d *stubResourceDef) String() string {
@@ -44,6 +48,10 @@ func (d *stubResourceDef) Compute(ctx *RequestContext, apiClient iaas.APICaller)
 		return d.computeFunc(ctx, apiClient)
 	}
 	return nil, nil
+}
+
+func (d *stubResourceDef) LastModifiedAt(ctx *RequestContext, apiClient iaas.APICaller) (time.Time, error) {
+	return d.lastModifiedAt, d.lastmodifiedAtErr
 }
 
 type stubResource struct {

--- a/docs/design/cooldown.md
+++ b/docs/design/cooldown.md
@@ -39,7 +39,22 @@ Note: 毎回のup/down実行時にさくらのクラウドAPI呼び出しが発�
 - `core.ResourceDefinitions`にも`LastModifiedAt(...)`を追加し、内包するResourceDefinitionsが返したmodified_atの内、最も遅い時間を示すmodified_atの値を返すようにする
 - `core.JobStatus`のfunc`Acceptable(...)`を上記のLastModifiedAt()を呼び出して判定するよう修正
 
+### 基準とするmodified_atフィールドについて
 
-### 更新内容
+ルータについてはmodified_atフィールドを持たない。  
+しかしルータのプラン変更時は新規リソースが作成されるためcreated_atで代用可能である。
+
+よってmodified_atだけでなくcreated_atも用いて判断する。
+
+#### modified_atはいつ変更されるか?
+
+- リソース作成時
+- プランを変更した時(実際にはリソースの新規作成にあたるため)
+- 電源操作時(サーバなど)
+
+Note: リソース名の変更など一部の操作ではmodifie_atが変更されない。
+
+## 更新内容
 
 - 2023/2/16: 作成
+- 2023/2/17: modified_atを持たないリソースが存在することへの考慮を追加

--- a/e2e/horizontal_scaling/autoscaler.yaml
+++ b/e2e/horizontal_scaling/autoscaler.yaml
@@ -40,4 +40,4 @@ resources:
       selector: "autoscaler-e2e-horizontal-scaling"
 
 autoscaler:
-  cooldown: 5
+  cooldown: 180

--- a/e2e/horizontal_scaling/e2e_test.go
+++ b/e2e/horizontal_scaling/e2e_test.go
@@ -114,7 +114,7 @@ func TestE2E_HorizontalScaling(t *testing.T) {
 	}
 
 	// 冷却期間待機
-	time.Sleep(5 * time.Second)
+	time.Sleep(180 * time.Second)
 
 	// Terraformステートのリフレッシュ(複数回IDが変更されるため毎回リフレッシュしておく)
 	e2e.TerraformRefresh() // nolint
@@ -148,7 +148,7 @@ func TestE2E_HorizontalScaling(t *testing.T) {
 	}
 
 	// 冷却期間待機
-	time.Sleep(5 * time.Second)
+	time.Sleep(180 * time.Second)
 
 	// Terraformステートのリフレッシュ(複数回IDが変更されるため毎回リフレッシュしておく)
 	e2e.TerraformRefresh() // nolint

--- a/e2e/vertical_scaling/autoscaler.yaml
+++ b/e2e/vertical_scaling/autoscaler.yaml
@@ -19,4 +19,4 @@ resources:
       selector: "autoscaler-e2e-vertical-scaling"
 
 autoscaler:
-  cooldown: 30
+  cooldown: 180

--- a/e2e/vertical_scaling/e2e_test.go
+++ b/e2e/vertical_scaling/e2e_test.go
@@ -102,6 +102,9 @@ func TestE2E_VerticalScaling(t *testing.T) {
 		t.Fatalf("grpc-health-prove: unexpected response: %s", string(out))
 	}
 
+	// 冷却期間待機(リソース更新日時が基準のため初回のスケールアップも影響を受ける)
+	time.Sleep(180 * time.Second)
+
 	/**************************************************************************
 	 * Step 1-1: スケールアップ
 	 *************************************************************************/
@@ -171,7 +174,7 @@ func TestE2E_VerticalScaling(t *testing.T) {
 	}
 
 	// 冷却期間待機
-	time.Sleep(30 * time.Second)
+	time.Sleep(180 * time.Second)
 
 	// Terraformステートのリフレッシュ(複数回IDが変更されるため毎回リフレッシュしておく)
 	e2e.TerraformRefresh() // nolint


### PR DESCRIPTION
closes #466 

https://github.com/sacloud/autoscaler/blob/main/docs/design/cooldown.md の実装

Note: この実装では親リソースのModifiedAtは考慮されない。