### PR TITLE
cooldownの基準時刻修正

### DIFF
--- a/core/resource_def_server_group.go
+++ b/core/resource_def_server_group.go
@@ -332,6 +332,8 @@ func (d *ResourceDefServerGroup) filterCloudServers(servers []*iaas.Server) []*i
 }
 
 // LastModifiedAt この定義が対象とするリソース(群)の最終更新日時を返す
+//
+// ServerGroupではModifiedAt or Instance.StatusChangedAtの最も遅い時刻を返す
 func (d *ResourceDefServerGroup) LastModifiedAt(ctx *RequestContext, apiClient iaas.APICaller) (time.Time, error) {
 	cloudResources, err := d.findCloudResources(ctx, apiClient)
 	if err != nil {
@@ -343,8 +345,14 @@ func (d *ResourceDefServerGroup) LastModifiedAt(ctx *RequestContext, apiClient i
 func (d *ResourceDefServerGroup) lastModifiedAt(cloudResources []*iaas.Server) time.Time {
 	last := time.Time{}
 	for _, r := range cloudResources {
-		if r.GetModifiedAt().After(last) {
-			last = r.GetModifiedAt()
+		times := []time.Time{
+			r.ModifiedAt,
+			r.InstanceStatusChangedAt,
+		}
+		for _, t := range times {
+			if t.After(last) {
+				last = t
+			}
 		}
 	}
 	return last

--- a/core/resource_def_server_group_test.go
+++ b/core/resource_def_server_group_test.go
@@ -1210,6 +1210,30 @@ func TestResourceDefServerGroup_lastModifiedAt(t *testing.T) {
 			},
 			want: time.UnixMilli(107),
 		},
+		{
+			name: "returns last modified-at from Server.InstanceStatusChangedAt",
+			args: args{
+				cloudResources: []*iaas.Server{
+					{ModifiedAt: time.UnixMilli(103), InstanceStatusChangedAt: time.UnixMilli(108)},
+					{ModifiedAt: time.UnixMilli(107)},
+					{ModifiedAt: time.UnixMilli(105)},
+					{ModifiedAt: time.UnixMilli(101)},
+				},
+			},
+			want: time.UnixMilli(108),
+		},
+		{
+			name: "returns last modified-at from Server.ModifiedAt",
+			args: args{
+				cloudResources: []*iaas.Server{
+					{ModifiedAt: time.UnixMilli(103), InstanceStatusChangedAt: time.UnixMilli(107)},
+					{ModifiedAt: time.UnixMilli(108)},
+					{ModifiedAt: time.UnixMilli(105)},
+					{ModifiedAt: time.UnixMilli(101)},
+				},
+			},
+			want: time.UnixMilli(108),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#475 の補完

Server or ServerGroupではcooldownの基準としてModifiedAt or InstanceStatusChangedAtを用いる。
これにより起動したばかりのサーバがスケーリング動作の対象となることを防ぐ。