### PR TITLE
downgrade: github.com/go-playground/validator to v10.15.4

### DIFF
--- a/core/resource_def_server_group_test.go
+++ b/core/resource_def_server_group_test.go
@@ -564,6 +564,38 @@ func TestResourceDefServerGroup_Validate(t *testing.T) {
 			want: nil,
 		},
 		{
+			name: "returns no error with network_interfaces",
+			def: &ResourceDefServerGroup{
+				ResourceDefBase: &ResourceDefBase{
+					TypeName: "ServerGroup",
+				},
+				ServerNamePrefix: "test",
+				Zones:            []string{"is1a"},
+				MinSize:          1,
+				MaxSize:          1,
+				Template: &ServerGroupInstanceTemplate{
+					Plan: &ServerGroupInstancePlan{
+						Core:   1,
+						Memory: 1,
+					},
+					NetworkInterfaces: []*ServerGroupNICTemplate{
+						{
+							Upstream: &ServerGroupNICUpstream{
+								selector: &ResourceSelector{Names: []string{"foobar"}},
+							},
+							AssignCidrBlock:  "192.168.0.11/24",
+							AssignNetMaskLen: 24,
+							DefaultRoute:     "192.168.0.1",
+							ExposeInfo: &ServerGroupNICMetadata{
+								Ports: []int{80},
+							},
+						},
+					},
+				},
+			},
+			want: nil,
+		},
+		{
 			name: "return error with zone and zones",
 			def: &ResourceDefServerGroup{
 				ResourceDefBase: &ResourceDefBase{

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,11 @@ module github.com/sacloud/autoscaler
 
 go 1.21
 
+replace github.com/go-playground/validator/v10 => github.com/go-playground/validator/v10 v10.15.4
+
 require (
 	github.com/c-robinson/iplib v1.0.8
-	github.com/go-playground/validator/v10 v10.19.0
+	github.com/go-playground/validator/v10 v10.16.0
 	github.com/goccy/go-yaml v1.11.3
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/o
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
-github.com/go-playground/validator/v10 v10.19.0 h1:ol+5Fu+cSq9JD7SoSqe04GMI92cbn0+wvQ3bZ8b/AU4=
-github.com/go-playground/validator/v10 v10.19.0/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
+github.com/go-playground/validator/v10 v10.15.4 h1:zMXza4EpOdooxPel5xDqXEdXG5r+WggpvnAKMsalBjs=
+github.com/go-playground/validator/v10 v10.15.4/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/goccy/go-yaml v1.11.3 h1:B3W9IdWbvrUu2OYQGwvU1nZtvMQJPBKgBUuweJjLj6I=
 github.com/goccy/go-yaml v1.11.3/go.mod h1:wKnAMd44+9JAAnGQpWVEgBzGt3YuTaQ4uXoHvE4m7WU=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=


### PR DESCRIPTION
https://github.com/go-playground/validator/pull/945 の影響により `192.168.0.11/24`のような入力がバリデーションエラーとなる。

対応として一旦go-playground/validatorをダウングレードする。