### PR TITLE
Fix YAML parsing issue by unmarshaling to string before checking

### DIFF
--- a/core/server_group_instance_template.go
+++ b/core/server_group_instance_template.go
@@ -540,7 +540,10 @@ type ServerGroupNICUpstream struct {
 }
 
 func (s *ServerGroupNICUpstream) UnmarshalYAML(ctx context.Context, data []byte) error {
-	if string(data) == "shared" {
+	var strData string
+	yaml.UnmarshalWithOptions(data, &strData, yaml.Strict()) //nolint:errcheck
+
+	if strData == "shared" {
 		*s = ServerGroupNICUpstream{raw: data, shared: true}
 		return nil
 	}

--- a/core/server_group_instance_template_test.go
+++ b/core/server_group_instance_template_test.go
@@ -132,6 +132,49 @@ func TestServerGroupNICUpstream_UnmarshalYAML(t *testing.T) {
 			},
 		},
 		{
+			name: "shared with quote",
+			args: args{
+				data: []byte(`"shared"`),
+			},
+			wantErr: false,
+			expect: &ServerGroupNICUpstream{
+				raw:      []byte(`"shared"`),
+				shared:   true,
+				selector: nil,
+			},
+		},
+		{
+			name: "shared with single quote",
+			args: args{
+				data: []byte(`'shared'`),
+			},
+			wantErr: false,
+			expect: &ServerGroupNICUpstream{
+				raw:      []byte(`'shared'`),
+				shared:   true,
+				selector: nil,
+			},
+		},
+		{
+			name: "shared with newline",
+			args: args{
+				data: []byte("shared\n"),
+			},
+			wantErr: false,
+			expect: &ServerGroupNICUpstream{
+				raw:      []byte("shared"),
+				shared:   true,
+				selector: nil,
+			},
+		},
+		{
+			name: "invalid 'shared' string",
+			args: args{
+				data: []byte(`'sha"red'`),
+			},
+			wantErr: true,
+		},
+		{
 			name: "selector",
 			args: args{
 				data: []byte(`names: ["test"]`),


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

一部のテストで以下のエラーが出ていた。

```
[1:1] string was used where mapping is expected
>  1 | shared
       ^
```

これはUnmarshal時にバイト列の末尾に改行が付与されたことで発生していた。
これを一度stringにUnmarshalすることで解消する。

### ドキュメントの変更は必要ですか？

no