### PR TITLE
feat: inputs direct keepサブコマンドの追加

### DIFF
--- a/commands/inputs/direct/cmd.go
+++ b/commands/inputs/direct/cmd.go
@@ -32,9 +32,9 @@ import (
 )
 
 var Command = &cobra.Command{
-	Use:       "direct {up | down} [flags]...",
+	Use:       "direct {up | down | keep} [flags]...",
 	Short:     "Send Up/Down request directly to Core server",
-	ValidArgs: []string{"up", "down"},
+	ValidArgs: []string{"up", "down", "keep"},
 	Args:      cobra.ExactValidArgs(1),
 	PreRunE: flags.ValidateMultiFunc(true,
 		flags.ValidateDestinationFlags,
@@ -108,6 +108,8 @@ func run(_ *cobra.Command, args []string) error {
 		f = req.Up
 	case "down":
 		f = req.Down
+	case "keep":
+		f = req.Keep
 	default:
 		return fmt.Errorf("invalid args: %v", args)
 	}


### PR DESCRIPTION
### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

#645 の一環
#649 で追加されたKeep()を呼び出すためのCLI Wrapperを実装する。

実行例
```
$ autoscaler inputs direct keep
Error: rpc error: code = Unimplemented desc = method Keep not implemented
```

### ドキュメントの変更は必要ですか？

no
