### PR TITLE
feat: added alias 'input' for 'inputs' subcommand

### DIFF
--- a/commands/inputs/inputs.go
+++ b/commands/inputs/inputs.go
@@ -25,6 +25,7 @@ import (
 
 var Command = &cobra.Command{
 	Use:           "inputs",
+	Aliases:       []string{"input"},
 	Short:         "A set of sub commands to manage autoscaler's inputs",
 	SilenceErrors: true,
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

`autoscaler inputs`サブコマンドに`input`というエイリアスを追加する。
よく間違えてムキーってなるので...

### ドキュメントの変更は必要ですか？

no