### PR TITLE
Handle scaling by default for non-Keep requests

### DIFF
--- a/core/resource_def_server_group.go
+++ b/core/resource_def_server_group.go
@@ -138,12 +138,10 @@ func (d *ResourceDefServerGroup) Compute(ctx *RequestContext, apiClient iaas.API
 	}
 
 	switch ctx.Request().requestType {
-	case requestTypeUp, requestTypeDown:
-		return d.buildInstancesForScaling(ctx, apiClient, cloudResources)
 	case requestTypeKeep:
 		return d.buildInstancesForKeep(ctx, apiClient, cloudResources)
 	default:
-		return nil, nil // 到達しないはず
+		return d.buildInstancesForScaling(ctx, apiClient, cloudResources)
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

水平スケールにおいて`resources`サブコマンドが動作しない。
これは #663 により追加されたもので、Up/Down/Keep以外の時に何もしない実装になっているため。
resourcesサブコマンドでは現在のリソースの状態を知るために各リソース定義の`Compute()`が呼ばれるが、この時にはUp/Down/KeepのいずれでもなくUnknownという状態で呼ばれる。
このため現在の分岐処理では正常に処理されないようになっていた。

このPRではここを是正し、デフォルトの処理 + Keepの場合の処理の2つに分岐を整理した。


### ドキュメントの変更は必要ですか？

no
