### PR TITLE
test: extend E2E horizontal scaling timeout to 60 minutes

### DIFF
--- a/e2e/horizontal_scaling/e2e_test.go
+++ b/e2e/horizontal_scaling/e2e_test.go
@@ -51,7 +51,7 @@ var (
 
 	zones               = []string{"tk1b", "is1b"}
 	proxyLBReadyTimeout = 5 * time.Minute
-	e2eTestTimeout      = 20 * time.Minute
+	e2eTestTimeout      = 60 * time.Minute
 
 	output *e2e.Output
 )


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

水平スケーリングのE2Eテスト (`TestE2E_HorizontalScaling`) における `e2eTestTimeout` を20分から60分に延長した。
これにより、テスト実行中の `context.WithTimeout` の制限が1200秒から3600秒となり、スケールアウト/イン待ちを含む処理がタイムアウトしにくくなる。

### ドキュメントの変更は必要ですか？

不要

<!-- for GitHub Copilot: レビューは日本語で実施してください -->